### PR TITLE
feat: Add daily study reminders at 6 PM

### DIFF
--- a/src/core/database/database_manager.py
+++ b/src/core/database/database_manager.py
@@ -46,6 +46,10 @@ class DatabaseManager:
         """Get comprehensive user statistics"""
         return self.user_repo.get_user_stats(telegram_id)
 
+    def get_all_active_users(self) -> list[User]:
+        """Get all active users"""
+        return self.user_repo.get_all_active_users()
+
     # Word methods
     def get_word_by_lemma(self, lemma: str) -> Word | None:
         """Get word by lemma"""

--- a/src/core/database/repositories/user_repository.py
+++ b/src/core/database/repositories/user_repository.py
@@ -113,6 +113,17 @@ class UserRepository:
             logger.error(f"Error deactivating user: {e}")
             return False
 
+    def get_all_active_users(self) -> list[User]:
+        """Get all active users"""
+        try:
+            with self.db_connection.get_connection() as conn:
+                cursor = conn.execute("SELECT * FROM users WHERE is_active = 1")
+                rows = cursor.fetchall()
+                return [dict(row) for row in rows] if rows else []
+        except Exception as e:
+            logger.error(f"Error getting all active users: {e}")
+            return []
+
     def get_user_stats(self, telegram_id: int) -> UserStats | None:
         """Get comprehensive user statistics"""
         try:

--- a/src/core/scheduler/__init__.py
+++ b/src/core/scheduler/__init__.py
@@ -1,0 +1,3 @@
+"""
+Scheduler module for periodic tasks
+"""

--- a/src/core/scheduler/reminder_scheduler.py
+++ b/src/core/scheduler/reminder_scheduler.py
@@ -1,0 +1,91 @@
+"""
+Daily reminder scheduler for sending study notifications
+"""
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Callable
+from datetime import datetime, time
+
+logger = logging.getLogger(__name__)
+
+
+class ReminderScheduler:
+    """Scheduler for daily study reminders"""
+
+    def __init__(self, send_reminder_callback: Callable[[int], None]):
+        self.send_reminder_callback = send_reminder_callback
+        self.is_running = False
+        self.task = None
+        self.reminder_time = time(18, 0)  # 6 PM
+
+    async def start(self):
+        """Start the reminder scheduler"""
+        if self.is_running:
+            logger.warning("Reminder scheduler is already running")
+            return
+
+        self.is_running = True
+        self.task = asyncio.create_task(self._schedule_loop())
+        logger.info("Reminder scheduler started")
+
+    async def stop(self):
+        """Stop the reminder scheduler"""
+        if not self.is_running:
+            return
+
+        self.is_running = False
+        if self.task:
+            self.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self.task
+        logger.info("Reminder scheduler stopped")
+
+    async def _schedule_loop(self):
+        """Main scheduling loop"""
+        while self.is_running:
+            try:
+                # Calculate next reminder time
+                next_reminder = self._get_next_reminder_time()
+                now = datetime.now()
+
+                # Calculate sleep duration
+                sleep_duration = (next_reminder - now).total_seconds()
+
+                if sleep_duration > 0:
+                    logger.info(f"Next reminder scheduled for {next_reminder}")
+                    await asyncio.sleep(sleep_duration)
+
+                # Send reminders if still running
+                if self.is_running:
+                    await self._send_daily_reminders()
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Error in reminder scheduler: {e}")
+                # Sleep for a minute before retrying
+                await asyncio.sleep(60)
+
+    def _get_next_reminder_time(self) -> datetime:
+        """Get the next reminder time"""
+        now = datetime.now()
+        today_reminder = datetime.combine(now.date(), self.reminder_time)
+
+        # If today's reminder time has passed, schedule for tomorrow
+        if now >= today_reminder:
+            from datetime import timedelta
+
+            tomorrow = now.date() + timedelta(days=1)
+            return datetime.combine(tomorrow, self.reminder_time)
+        else:
+            return today_reminder
+
+    async def _send_daily_reminders(self):
+        """Send daily reminders to all users"""
+        try:
+            logger.info("Sending daily reminders to all active users")
+            await self.send_reminder_callback()
+        except Exception as e:
+            logger.error(f"Error sending daily reminders: {e}")

--- a/tests/test_daily_reminders.py
+++ b/tests/test_daily_reminders.py
@@ -2,13 +2,14 @@
 Test cases for daily reminders functionality
 """
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from src.bot_handler import BotHandler
+from src.core.database.connection import DatabaseConnection
 from src.core.database.database_manager import DatabaseManager
 from src.core.database.repositories.user_repository import UserRepository
-from src.core.database.connection import DatabaseConnection
 
 
 class TestGetAllActiveUsers:
@@ -27,7 +28,9 @@ class TestGetAllActiveUsers:
     @pytest.fixture
     def db_manager(self, mock_db_connection):
         """Create DatabaseManager with mocked connection"""
-        with patch('src.core.database.database_manager.DatabaseConnection') as mock_conn_class:
+        with patch(
+            "src.core.database.database_manager.DatabaseConnection"
+        ) as mock_conn_class:
             mock_conn_class.return_value = mock_db_connection
             return DatabaseManager()
 
@@ -36,58 +39,64 @@ class TestGetAllActiveUsers:
         # Mock database response
         mock_cursor = MagicMock()
         mock_row1 = {
-            'id': 1,
-            'telegram_id': 123456,
-            'first_name': 'John',
-            'last_name': 'Doe',
-            'username': 'johndoe',
-            'is_active': 1,
-            'created_at': '2024-01-01 10:00:00',
-            'updated_at': '2024-01-01 10:00:00'
+            "id": 1,
+            "telegram_id": 123456,
+            "first_name": "John",
+            "last_name": "Doe",
+            "username": "johndoe",
+            "is_active": 1,
+            "created_at": "2024-01-01 10:00:00",
+            "updated_at": "2024-01-01 10:00:00",
         }
         mock_row2 = {
-            'id': 2,
-            'telegram_id': 789012,
-            'first_name': 'Jane',
-            'last_name': 'Smith',
-            'username': 'janesmith',
-            'is_active': 1,
-            'created_at': '2024-01-02 11:00:00',
-            'updated_at': '2024-01-02 11:00:00'
+            "id": 2,
+            "telegram_id": 789012,
+            "first_name": "Jane",
+            "last_name": "Smith",
+            "username": "janesmith",
+            "is_active": 1,
+            "created_at": "2024-01-02 11:00:00",
+            "updated_at": "2024-01-02 11:00:00",
         }
-        
+
         mock_cursor.fetchall.return_value = [mock_row1, mock_row2]
-        
+
         mock_conn = MagicMock()
         mock_conn.execute.return_value = mock_cursor
-        mock_db_connection.get_connection.return_value.__enter__.return_value = mock_conn
-        
+        mock_db_connection.get_connection.return_value.__enter__.return_value = (
+            mock_conn
+        )
+
         # Test the method
         result = user_repo.get_all_active_users()
-        
+
         # Verify results
         assert len(result) == 2
-        assert result[0]['telegram_id'] == 123456
-        assert result[0]['first_name'] == 'John'
-        assert result[1]['telegram_id'] == 789012
-        assert result[1]['first_name'] == 'Jane'
-        
+        assert result[0]["telegram_id"] == 123456
+        assert result[0]["first_name"] == "John"
+        assert result[1]["telegram_id"] == 789012
+        assert result[1]["first_name"] == "Jane"
+
         # Verify SQL query
-        mock_conn.execute.assert_called_once_with("SELECT * FROM users WHERE is_active = 1")
+        mock_conn.execute.assert_called_once_with(
+            "SELECT * FROM users WHERE is_active = 1"
+        )
 
     def test_get_all_active_users_empty_result(self, user_repo, mock_db_connection):
         """Test when no active users found"""
         # Mock empty database response
         mock_cursor = MagicMock()
         mock_cursor.fetchall.return_value = []
-        
+
         mock_conn = MagicMock()
         mock_conn.execute.return_value = mock_cursor
-        mock_db_connection.get_connection.return_value.__enter__.return_value = mock_conn
-        
+        mock_db_connection.get_connection.return_value.__enter__.return_value = (
+            mock_conn
+        )
+
         # Test the method
         result = user_repo.get_all_active_users()
-        
+
         # Verify empty result
         assert result == []
 
@@ -96,38 +105,42 @@ class TestGetAllActiveUsers:
         # Mock None database response
         mock_cursor = MagicMock()
         mock_cursor.fetchall.return_value = None
-        
+
         mock_conn = MagicMock()
         mock_conn.execute.return_value = mock_cursor
-        mock_db_connection.get_connection.return_value.__enter__.return_value = mock_conn
-        
+        mock_db_connection.get_connection.return_value.__enter__.return_value = (
+            mock_conn
+        )
+
         # Test the method
         result = user_repo.get_all_active_users()
-        
+
         # Verify empty result for None
         assert result == []
 
     def test_get_all_active_users_database_error(self, user_repo, mock_db_connection):
         """Test handling of database errors"""
         # Mock database error
-        mock_db_connection.get_connection.side_effect = Exception("Database connection failed")
-        
+        mock_db_connection.get_connection.side_effect = Exception(
+            "Database connection failed"
+        )
+
         # Test the method
         result = user_repo.get_all_active_users()
-        
+
         # Should return empty list on error
         assert result == []
 
     def test_database_manager_get_all_active_users(self, db_manager):
         """Test DatabaseManager.get_all_active_users delegates to UserRepository"""
-        with patch.object(db_manager.user_repo, 'get_all_active_users') as mock_method:
-            mock_method.return_value = [{'telegram_id': 123, 'first_name': 'Test'}]
-            
+        with patch.object(db_manager.user_repo, "get_all_active_users") as mock_method:
+            mock_method.return_value = [{"telegram_id": 123, "first_name": "Test"}]
+
             result = db_manager.get_all_active_users()
-            
+
             mock_method.assert_called_once()
             assert len(result) == 1
-            assert result[0]['telegram_id'] == 123
+            assert result[0]["telegram_id"] == 123
 
 
 class TestSendDailyReminders:
@@ -155,17 +168,18 @@ class TestSendDailyReminders:
     @pytest.fixture
     def bot_handler(self, mock_settings):
         """Create BotHandler with mocked dependencies"""
-        with patch('src.bot_handler.get_db_manager'), \
-             patch('src.bot_handler.get_word_processor'), \
-             patch('src.bot_handler.get_text_parser'), \
-             patch('src.bot_handler.get_srs_system'), \
-             patch('src.bot_handler.UserLockManager'), \
-             patch('src.bot_handler.UserStateManager'), \
-             patch('src.bot_handler.ReminderScheduler'), \
-             patch('src.bot_handler.SessionManager'), \
-             patch('src.bot_handler.CommandHandlers'), \
-             patch('src.bot_handler.MessageHandlers'):
-            
+        with (
+            patch("src.bot_handler.get_db_manager"),
+            patch("src.bot_handler.get_word_processor"),
+            patch("src.bot_handler.get_text_parser"),
+            patch("src.bot_handler.get_srs_system"),
+            patch("src.bot_handler.UserLockManager"),
+            patch("src.bot_handler.UserStateManager"),
+            patch("src.bot_handler.ReminderScheduler"),
+            patch("src.bot_handler.SessionManager"),
+            patch("src.bot_handler.CommandHandlers"),
+            patch("src.bot_handler.MessageHandlers"),
+        ):
             return BotHandler(mock_settings)
 
     @pytest.mark.asyncio
@@ -173,97 +187,107 @@ class TestSendDailyReminders:
         """Test successful sending of daily reminders"""
         # Mock active users
         mock_users = [
-            {'telegram_id': 123456, 'first_name': 'John'},
-            {'telegram_id': 789012, 'first_name': 'Jane'}
+            {"telegram_id": 123456, "first_name": "John"},
+            {"telegram_id": 789012, "first_name": "Jane"},
         ]
-        
+
         bot_handler.db_manager = MagicMock()
         bot_handler.db_manager.get_all_active_users.return_value = mock_users
         bot_handler.application = mock_application
-        
+
         # Test the method
         await bot_handler._send_daily_reminders()
-        
+
         # Verify messages were sent to all users
         assert mock_application.bot.send_message.call_count == 2
-        
+
         # Check first call
         first_call = mock_application.bot.send_message.call_args_list[0]
-        assert first_call[1]['chat_id'] == 123456
-        assert "Время изучения немецкого!" in first_call[1]['text']
-        assert first_call[1]['parse_mode'] == "HTML"
-        
+        assert first_call[1]["chat_id"] == 123456
+        assert "Время изучения немецкого!" in first_call[1]["text"]
+        assert first_call[1]["parse_mode"] == "HTML"
+
         # Check second call
         second_call = mock_application.bot.send_message.call_args_list[1]
-        assert second_call[1]['chat_id'] == 789012
-        assert "Время изучения немецкого!" in second_call[1]['text']
+        assert second_call[1]["chat_id"] == 789012
+        assert "Время изучения немецкого!" in second_call[1]["text"]
 
     @pytest.mark.asyncio
-    async def test_send_daily_reminders_no_active_users(self, bot_handler, mock_application):
+    async def test_send_daily_reminders_no_active_users(
+        self, bot_handler, mock_application
+    ):
         """Test when no active users found"""
         bot_handler.db_manager = MagicMock()
         bot_handler.db_manager.get_all_active_users.return_value = []
         bot_handler.application = mock_application
-        
+
         # Test the method
         await bot_handler._send_daily_reminders()
-        
+
         # Verify no messages were sent
         mock_application.bot.send_message.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_send_daily_reminders_partial_failure(self, bot_handler, mock_application):
+    async def test_send_daily_reminders_partial_failure(
+        self, bot_handler, mock_application
+    ):
         """Test when some message sends fail"""
         # Mock active users
         mock_users = [
-            {'telegram_id': 123456, 'first_name': 'John'},
-            {'telegram_id': 789012, 'first_name': 'Jane'}
+            {"telegram_id": 123456, "first_name": "John"},
+            {"telegram_id": 789012, "first_name": "Jane"},
         ]
-        
+
         bot_handler.db_manager = MagicMock()
         bot_handler.db_manager.get_all_active_users.return_value = mock_users
         bot_handler.application = mock_application
-        
+
         # Mock first send success, second send failure
         mock_application.bot.send_message.side_effect = [
             AsyncMock(),  # Success
-            Exception("Send failed")  # Failure
+            Exception("Send failed"),  # Failure
         ]
-        
+
         # Test the method - should not raise exception
         await bot_handler._send_daily_reminders()
-        
+
         # Verify both sends were attempted
         assert mock_application.bot.send_message.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_send_daily_reminders_database_error(self, bot_handler, mock_application):
+    async def test_send_daily_reminders_database_error(
+        self, bot_handler, mock_application
+    ):
         """Test when database error occurs"""
         bot_handler.db_manager = MagicMock()
-        bot_handler.db_manager.get_all_active_users.side_effect = Exception("Database error")
+        bot_handler.db_manager.get_all_active_users.side_effect = Exception(
+            "Database error"
+        )
         bot_handler.application = mock_application
-        
+
         # Test the method - should not raise exception
         await bot_handler._send_daily_reminders()
-        
+
         # Verify no messages were sent
         mock_application.bot.send_message.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_send_daily_reminders_message_content(self, bot_handler, mock_application):
+    async def test_send_daily_reminders_message_content(
+        self, bot_handler, mock_application
+    ):
         """Test the content of reminder messages"""
-        mock_users = [{'telegram_id': 123456, 'first_name': 'John'}]
-        
+        mock_users = [{"telegram_id": 123456, "first_name": "John"}]
+
         bot_handler.db_manager = MagicMock()
         bot_handler.db_manager.get_all_active_users.return_value = mock_users
         bot_handler.application = mock_application
-        
+
         await bot_handler._send_daily_reminders()
-        
+
         # Get the message content
         call_args = mock_application.bot.send_message.call_args
-        message_text = call_args[1]['text']
-        
+        message_text = call_args[1]["text"]
+
         # Verify message content
         assert "🎯" in message_text
         assert "Время изучения немецкого!" in message_text
@@ -281,25 +305,28 @@ class TestDailyRemindersIntegration:
         mock_settings = MagicMock()
         mock_settings.telegram_bot_token = "test_token"
         mock_settings.allowed_users_list = []
-        
-        with patch('src.bot_handler.get_db_manager'), \
-             patch('src.bot_handler.get_word_processor'), \
-             patch('src.bot_handler.get_text_parser'), \
-             patch('src.bot_handler.get_srs_system'), \
-             patch('src.bot_handler.UserLockManager'), \
-             patch('src.bot_handler.UserStateManager'), \
-             patch('src.bot_handler.SessionManager'), \
-             patch('src.bot_handler.CommandHandlers'), \
-             patch('src.bot_handler.MessageHandlers'), \
-             patch('src.bot_handler.ReminderScheduler') as mock_scheduler_class:
-            
+
+        with (
+            patch("src.bot_handler.get_db_manager"),
+            patch("src.bot_handler.get_word_processor"),
+            patch("src.bot_handler.get_text_parser"),
+            patch("src.bot_handler.get_srs_system"),
+            patch("src.bot_handler.UserLockManager"),
+            patch("src.bot_handler.UserStateManager"),
+            patch("src.bot_handler.SessionManager"),
+            patch("src.bot_handler.CommandHandlers"),
+            patch("src.bot_handler.MessageHandlers"),
+            patch("src.bot_handler.ReminderScheduler") as mock_scheduler_class,
+        ):
             mock_scheduler = MagicMock()
             mock_scheduler_class.return_value = mock_scheduler
-            
+
             bot_handler = BotHandler(mock_settings)
-            
+
             # Verify scheduler was created with correct callback
-            mock_scheduler_class.assert_called_once_with(bot_handler._send_daily_reminders)
+            mock_scheduler_class.assert_called_once_with(
+                bot_handler._send_daily_reminders
+            )
             assert bot_handler.reminder_scheduler == mock_scheduler
 
     def test_reminder_scheduler_lifecycle_in_bot_start(self):
@@ -307,55 +334,60 @@ class TestDailyRemindersIntegration:
         mock_settings = MagicMock()
         mock_settings.telegram_bot_token = "test_token"
         mock_settings.allowed_users_list = []
-        
-        with patch('src.bot_handler.get_db_manager'), \
-             patch('src.bot_handler.get_word_processor'), \
-             patch('src.bot_handler.get_text_parser'), \
-             patch('src.bot_handler.get_srs_system'), \
-             patch('src.bot_handler.UserLockManager') as mock_lock_manager_class, \
-             patch('src.bot_handler.UserStateManager') as mock_state_manager_class, \
-             patch('src.bot_handler.SessionManager'), \
-             patch('src.bot_handler.CommandHandlers'), \
-             patch('src.bot_handler.MessageHandlers'), \
-             patch('src.bot_handler.ReminderScheduler') as mock_scheduler_class:
-            
+
+        with (
+            patch("src.bot_handler.get_db_manager"),
+            patch("src.bot_handler.get_word_processor"),
+            patch("src.bot_handler.get_text_parser"),
+            patch("src.bot_handler.get_srs_system"),
+            patch("src.bot_handler.UserLockManager") as mock_lock_manager_class,
+            patch("src.bot_handler.UserStateManager") as mock_state_manager_class,
+            patch("src.bot_handler.SessionManager"),
+            patch("src.bot_handler.CommandHandlers"),
+            patch("src.bot_handler.MessageHandlers"),
+            patch("src.bot_handler.ReminderScheduler") as mock_scheduler_class,
+        ):
             mock_scheduler = MagicMock()
             mock_scheduler_class.return_value = mock_scheduler
-            
+
             mock_lock_manager = MagicMock()
             mock_lock_manager_class.return_value = mock_lock_manager
-            
+
             mock_state_manager = MagicMock()
             mock_state_manager_class.return_value = mock_state_manager
-            
+
             bot_handler = BotHandler(mock_settings)
-            
+
             # Verify scheduler was created with correct callback
-            mock_scheduler_class.assert_called_once_with(bot_handler._send_daily_reminders)
+            mock_scheduler_class.assert_called_once_with(
+                bot_handler._send_daily_reminders
+            )
             assert bot_handler.reminder_scheduler == mock_scheduler
 
     def test_reminder_message_format_consistency(self):
         """Test that reminder message format is consistent"""
         mock_settings = MagicMock()
-        
-        with patch('src.bot_handler.get_db_manager'), \
-             patch('src.bot_handler.get_word_processor'), \
-             patch('src.bot_handler.get_text_parser'), \
-             patch('src.bot_handler.get_srs_system'), \
-             patch('src.bot_handler.UserLockManager'), \
-             patch('src.bot_handler.UserStateManager'), \
-             patch('src.bot_handler.ReminderScheduler'), \
-             patch('src.bot_handler.SessionManager'), \
-             patch('src.bot_handler.CommandHandlers'), \
-             patch('src.bot_handler.MessageHandlers'):
-            
+
+        with (
+            patch("src.bot_handler.get_db_manager"),
+            patch("src.bot_handler.get_word_processor"),
+            patch("src.bot_handler.get_text_parser"),
+            patch("src.bot_handler.get_srs_system"),
+            patch("src.bot_handler.UserLockManager"),
+            patch("src.bot_handler.UserStateManager"),
+            patch("src.bot_handler.ReminderScheduler"),
+            patch("src.bot_handler.SessionManager"),
+            patch("src.bot_handler.CommandHandlers"),
+            patch("src.bot_handler.MessageHandlers"),
+        ):
             bot_handler = BotHandler(mock_settings)
-            
+
             # Extract the message from the method (by examining the source)
             # This ensures the message format is what we expect
             import inspect
+
             source = inspect.getsource(bot_handler._send_daily_reminders)
-            
+
             # Verify key components are in the message
             assert "Время изучения немецкого!" in source
             assert "Не забудьте позаниматься сегодня" in source

--- a/tests/test_daily_reminders.py
+++ b/tests/test_daily_reminders.py
@@ -1,0 +1,364 @@
+"""
+Test cases for daily reminders functionality
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.bot_handler import BotHandler
+from src.core.database.database_manager import DatabaseManager
+from src.core.database.repositories.user_repository import UserRepository
+from src.core.database.connection import DatabaseConnection
+
+
+class TestGetAllActiveUsers:
+    """Test cases for get_all_active_users functionality"""
+
+    @pytest.fixture
+    def mock_db_connection(self):
+        """Mock database connection"""
+        return MagicMock(spec=DatabaseConnection)
+
+    @pytest.fixture
+    def user_repo(self, mock_db_connection):
+        """Create UserRepository with mocked connection"""
+        return UserRepository(mock_db_connection)
+
+    @pytest.fixture
+    def db_manager(self, mock_db_connection):
+        """Create DatabaseManager with mocked connection"""
+        with patch('src.core.database.database_manager.DatabaseConnection') as mock_conn_class:
+            mock_conn_class.return_value = mock_db_connection
+            return DatabaseManager()
+
+    def test_get_all_active_users_success(self, user_repo, mock_db_connection):
+        """Test successful retrieval of active users"""
+        # Mock database response
+        mock_cursor = MagicMock()
+        mock_row1 = {
+            'id': 1,
+            'telegram_id': 123456,
+            'first_name': 'John',
+            'last_name': 'Doe',
+            'username': 'johndoe',
+            'is_active': 1,
+            'created_at': '2024-01-01 10:00:00',
+            'updated_at': '2024-01-01 10:00:00'
+        }
+        mock_row2 = {
+            'id': 2,
+            'telegram_id': 789012,
+            'first_name': 'Jane',
+            'last_name': 'Smith',
+            'username': 'janesmith',
+            'is_active': 1,
+            'created_at': '2024-01-02 11:00:00',
+            'updated_at': '2024-01-02 11:00:00'
+        }
+        
+        mock_cursor.fetchall.return_value = [mock_row1, mock_row2]
+        
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value = mock_cursor
+        mock_db_connection.get_connection.return_value.__enter__.return_value = mock_conn
+        
+        # Test the method
+        result = user_repo.get_all_active_users()
+        
+        # Verify results
+        assert len(result) == 2
+        assert result[0]['telegram_id'] == 123456
+        assert result[0]['first_name'] == 'John'
+        assert result[1]['telegram_id'] == 789012
+        assert result[1]['first_name'] == 'Jane'
+        
+        # Verify SQL query
+        mock_conn.execute.assert_called_once_with("SELECT * FROM users WHERE is_active = 1")
+
+    def test_get_all_active_users_empty_result(self, user_repo, mock_db_connection):
+        """Test when no active users found"""
+        # Mock empty database response
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value = mock_cursor
+        mock_db_connection.get_connection.return_value.__enter__.return_value = mock_conn
+        
+        # Test the method
+        result = user_repo.get_all_active_users()
+        
+        # Verify empty result
+        assert result == []
+
+    def test_get_all_active_users_none_result(self, user_repo, mock_db_connection):
+        """Test when database returns None"""
+        # Mock None database response
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = None
+        
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value = mock_cursor
+        mock_db_connection.get_connection.return_value.__enter__.return_value = mock_conn
+        
+        # Test the method
+        result = user_repo.get_all_active_users()
+        
+        # Verify empty result for None
+        assert result == []
+
+    def test_get_all_active_users_database_error(self, user_repo, mock_db_connection):
+        """Test handling of database errors"""
+        # Mock database error
+        mock_db_connection.get_connection.side_effect = Exception("Database connection failed")
+        
+        # Test the method
+        result = user_repo.get_all_active_users()
+        
+        # Should return empty list on error
+        assert result == []
+
+    def test_database_manager_get_all_active_users(self, db_manager):
+        """Test DatabaseManager.get_all_active_users delegates to UserRepository"""
+        with patch.object(db_manager.user_repo, 'get_all_active_users') as mock_method:
+            mock_method.return_value = [{'telegram_id': 123, 'first_name': 'Test'}]
+            
+            result = db_manager.get_all_active_users()
+            
+            mock_method.assert_called_once()
+            assert len(result) == 1
+            assert result[0]['telegram_id'] == 123
+
+
+class TestSendDailyReminders:
+    """Test cases for _send_daily_reminders method"""
+
+    @pytest.fixture
+    def mock_settings(self):
+        """Mock settings for BotHandler"""
+        settings = MagicMock()
+        settings.telegram_bot_token = "test_token"
+        settings.allowed_users_list = [123456, 789012]
+        settings.max_words_per_request = 50
+        settings.polling_interval = 1.0
+        settings.log_level = "INFO"
+        return settings
+
+    @pytest.fixture
+    def mock_application(self):
+        """Mock Telegram application"""
+        app = MagicMock()
+        app.bot = MagicMock()
+        app.bot.send_message = AsyncMock()
+        return app
+
+    @pytest.fixture
+    def bot_handler(self, mock_settings):
+        """Create BotHandler with mocked dependencies"""
+        with patch('src.bot_handler.get_db_manager'), \
+             patch('src.bot_handler.get_word_processor'), \
+             patch('src.bot_handler.get_text_parser'), \
+             patch('src.bot_handler.get_srs_system'), \
+             patch('src.bot_handler.UserLockManager'), \
+             patch('src.bot_handler.UserStateManager'), \
+             patch('src.bot_handler.ReminderScheduler'), \
+             patch('src.bot_handler.SessionManager'), \
+             patch('src.bot_handler.CommandHandlers'), \
+             patch('src.bot_handler.MessageHandlers'):
+            
+            return BotHandler(mock_settings)
+
+    @pytest.mark.asyncio
+    async def test_send_daily_reminders_success(self, bot_handler, mock_application):
+        """Test successful sending of daily reminders"""
+        # Mock active users
+        mock_users = [
+            {'telegram_id': 123456, 'first_name': 'John'},
+            {'telegram_id': 789012, 'first_name': 'Jane'}
+        ]
+        
+        bot_handler.db_manager = MagicMock()
+        bot_handler.db_manager.get_all_active_users.return_value = mock_users
+        bot_handler.application = mock_application
+        
+        # Test the method
+        await bot_handler._send_daily_reminders()
+        
+        # Verify messages were sent to all users
+        assert mock_application.bot.send_message.call_count == 2
+        
+        # Check first call
+        first_call = mock_application.bot.send_message.call_args_list[0]
+        assert first_call[1]['chat_id'] == 123456
+        assert "Время изучения немецкого!" in first_call[1]['text']
+        assert first_call[1]['parse_mode'] == "HTML"
+        
+        # Check second call
+        second_call = mock_application.bot.send_message.call_args_list[1]
+        assert second_call[1]['chat_id'] == 789012
+        assert "Время изучения немецкого!" in second_call[1]['text']
+
+    @pytest.mark.asyncio
+    async def test_send_daily_reminders_no_active_users(self, bot_handler, mock_application):
+        """Test when no active users found"""
+        bot_handler.db_manager = MagicMock()
+        bot_handler.db_manager.get_all_active_users.return_value = []
+        bot_handler.application = mock_application
+        
+        # Test the method
+        await bot_handler._send_daily_reminders()
+        
+        # Verify no messages were sent
+        mock_application.bot.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_daily_reminders_partial_failure(self, bot_handler, mock_application):
+        """Test when some message sends fail"""
+        # Mock active users
+        mock_users = [
+            {'telegram_id': 123456, 'first_name': 'John'},
+            {'telegram_id': 789012, 'first_name': 'Jane'}
+        ]
+        
+        bot_handler.db_manager = MagicMock()
+        bot_handler.db_manager.get_all_active_users.return_value = mock_users
+        bot_handler.application = mock_application
+        
+        # Mock first send success, second send failure
+        mock_application.bot.send_message.side_effect = [
+            AsyncMock(),  # Success
+            Exception("Send failed")  # Failure
+        ]
+        
+        # Test the method - should not raise exception
+        await bot_handler._send_daily_reminders()
+        
+        # Verify both sends were attempted
+        assert mock_application.bot.send_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_send_daily_reminders_database_error(self, bot_handler, mock_application):
+        """Test when database error occurs"""
+        bot_handler.db_manager = MagicMock()
+        bot_handler.db_manager.get_all_active_users.side_effect = Exception("Database error")
+        bot_handler.application = mock_application
+        
+        # Test the method - should not raise exception
+        await bot_handler._send_daily_reminders()
+        
+        # Verify no messages were sent
+        mock_application.bot.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_daily_reminders_message_content(self, bot_handler, mock_application):
+        """Test the content of reminder messages"""
+        mock_users = [{'telegram_id': 123456, 'first_name': 'John'}]
+        
+        bot_handler.db_manager = MagicMock()
+        bot_handler.db_manager.get_all_active_users.return_value = mock_users
+        bot_handler.application = mock_application
+        
+        await bot_handler._send_daily_reminders()
+        
+        # Get the message content
+        call_args = mock_application.bot.send_message.call_args
+        message_text = call_args[1]['text']
+        
+        # Verify message content
+        assert "🎯" in message_text
+        assert "Время изучения немецкого!" in message_text
+        assert "📚 Не забудьте позаниматься сегодня." in message_text
+        assert "💪 Регулярные занятия — ключ к успеху!" in message_text
+        assert "/study" in message_text
+
+
+class TestDailyRemindersIntegration:
+    """Integration tests for daily reminders functionality"""
+
+    @pytest.mark.asyncio
+    async def test_bot_handler_reminder_scheduler_integration(self):
+        """Test that BotHandler properly integrates with ReminderScheduler"""
+        mock_settings = MagicMock()
+        mock_settings.telegram_bot_token = "test_token"
+        mock_settings.allowed_users_list = []
+        
+        with patch('src.bot_handler.get_db_manager'), \
+             patch('src.bot_handler.get_word_processor'), \
+             patch('src.bot_handler.get_text_parser'), \
+             patch('src.bot_handler.get_srs_system'), \
+             patch('src.bot_handler.UserLockManager'), \
+             patch('src.bot_handler.UserStateManager'), \
+             patch('src.bot_handler.SessionManager'), \
+             patch('src.bot_handler.CommandHandlers'), \
+             patch('src.bot_handler.MessageHandlers'), \
+             patch('src.bot_handler.ReminderScheduler') as mock_scheduler_class:
+            
+            mock_scheduler = MagicMock()
+            mock_scheduler_class.return_value = mock_scheduler
+            
+            bot_handler = BotHandler(mock_settings)
+            
+            # Verify scheduler was created with correct callback
+            mock_scheduler_class.assert_called_once_with(bot_handler._send_daily_reminders)
+            assert bot_handler.reminder_scheduler == mock_scheduler
+
+    def test_reminder_scheduler_lifecycle_in_bot_start(self):
+        """Test that reminder scheduler is started/stopped with bot"""
+        mock_settings = MagicMock()
+        mock_settings.telegram_bot_token = "test_token"
+        mock_settings.allowed_users_list = []
+        
+        with patch('src.bot_handler.get_db_manager'), \
+             patch('src.bot_handler.get_word_processor'), \
+             patch('src.bot_handler.get_text_parser'), \
+             patch('src.bot_handler.get_srs_system'), \
+             patch('src.bot_handler.UserLockManager') as mock_lock_manager_class, \
+             patch('src.bot_handler.UserStateManager') as mock_state_manager_class, \
+             patch('src.bot_handler.SessionManager'), \
+             patch('src.bot_handler.CommandHandlers'), \
+             patch('src.bot_handler.MessageHandlers'), \
+             patch('src.bot_handler.ReminderScheduler') as mock_scheduler_class:
+            
+            mock_scheduler = MagicMock()
+            mock_scheduler_class.return_value = mock_scheduler
+            
+            mock_lock_manager = MagicMock()
+            mock_lock_manager_class.return_value = mock_lock_manager
+            
+            mock_state_manager = MagicMock()
+            mock_state_manager_class.return_value = mock_state_manager
+            
+            bot_handler = BotHandler(mock_settings)
+            
+            # Verify scheduler was created with correct callback
+            mock_scheduler_class.assert_called_once_with(bot_handler._send_daily_reminders)
+            assert bot_handler.reminder_scheduler == mock_scheduler
+
+    def test_reminder_message_format_consistency(self):
+        """Test that reminder message format is consistent"""
+        mock_settings = MagicMock()
+        
+        with patch('src.bot_handler.get_db_manager'), \
+             patch('src.bot_handler.get_word_processor'), \
+             patch('src.bot_handler.get_text_parser'), \
+             patch('src.bot_handler.get_srs_system'), \
+             patch('src.bot_handler.UserLockManager'), \
+             patch('src.bot_handler.UserStateManager'), \
+             patch('src.bot_handler.ReminderScheduler'), \
+             patch('src.bot_handler.SessionManager'), \
+             patch('src.bot_handler.CommandHandlers'), \
+             patch('src.bot_handler.MessageHandlers'):
+            
+            bot_handler = BotHandler(mock_settings)
+            
+            # Extract the message from the method (by examining the source)
+            # This ensures the message format is what we expect
+            import inspect
+            source = inspect.getsource(bot_handler._send_daily_reminders)
+            
+            # Verify key components are in the message
+            assert "Время изучения немецкого!" in source
+            assert "Не забудьте позаниматься сегодня" in source
+            assert "Регулярные занятия — ключ к успеху" in source
+            assert "/study" in source
+            assert "HTML" in source  # parse_mode

--- a/tests/test_reminder_scheduler.py
+++ b/tests/test_reminder_scheduler.py
@@ -1,0 +1,260 @@
+"""
+Test cases for the ReminderScheduler functionality
+"""
+
+import asyncio
+import pytest
+from datetime import datetime, time, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.core.scheduler.reminder_scheduler import ReminderScheduler
+
+
+class TestReminderScheduler:
+    """Test cases for ReminderScheduler class"""
+
+    @pytest.fixture
+    def mock_callback(self):
+        """Mock callback for reminder scheduler"""
+        return AsyncMock()
+
+    @pytest.fixture
+    def scheduler(self, mock_callback):
+        """Create a ReminderScheduler instance for testing"""
+        return ReminderScheduler(mock_callback)
+
+    def test_reminder_scheduler_initialization(self, mock_callback):
+        """Test ReminderScheduler initialization"""
+        scheduler = ReminderScheduler(mock_callback)
+        
+        assert scheduler.send_reminder_callback == mock_callback
+        assert scheduler.is_running is False
+        assert scheduler.task is None
+        assert scheduler.reminder_time == time(18, 0)
+
+    @pytest.mark.asyncio
+    async def test_start_scheduler(self, scheduler):
+        """Test starting the reminder scheduler"""
+        assert scheduler.is_running is False
+        
+        # Start scheduler
+        await scheduler.start()
+        
+        assert scheduler.is_running is True
+        assert scheduler.task is not None
+        assert not scheduler.task.done()
+        
+        # Clean up
+        await scheduler.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_scheduler(self, scheduler):
+        """Test stopping the reminder scheduler"""
+        # Start first
+        await scheduler.start()
+        assert scheduler.is_running is True
+        
+        # Stop
+        await scheduler.stop()
+        
+        assert scheduler.is_running is False
+        # Task should be cancelled
+        if scheduler.task:
+            assert scheduler.task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_start_already_running_scheduler(self, scheduler):
+        """Test starting scheduler when already running"""
+        await scheduler.start()
+        
+        # Try to start again
+        await scheduler.start()
+        
+        # Should still be running
+        assert scheduler.is_running is True
+        
+        # Clean up
+        await scheduler.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_not_running_scheduler(self, scheduler):
+        """Test stopping scheduler when not running"""
+        assert scheduler.is_running is False
+        
+        # Should not raise exception
+        await scheduler.stop()
+        
+        assert scheduler.is_running is False
+
+    def test_get_next_reminder_time_today(self, scheduler):
+        """Test getting next reminder time when today's time hasn't passed"""
+        # Mock current time to be 17:00 (before 18:00)
+        with patch('src.core.scheduler.reminder_scheduler.datetime') as mock_datetime:
+            mock_now = datetime(2024, 1, 15, 17, 0, 0)  # 5 PM
+            mock_datetime.now.return_value = mock_now
+            mock_datetime.combine = datetime.combine
+            
+            next_reminder = scheduler._get_next_reminder_time()
+            
+            expected = datetime(2024, 1, 15, 18, 0, 0)  # Today at 6 PM
+            assert next_reminder == expected
+
+    def test_get_next_reminder_time_tomorrow(self, scheduler):
+        """Test getting next reminder time when today's time has passed"""
+        # Mock current time to be 19:00 (after 18:00)
+        with patch('src.core.scheduler.reminder_scheduler.datetime') as mock_datetime:
+            mock_now = datetime(2024, 1, 15, 19, 0, 0)  # 7 PM
+            mock_datetime.now.return_value = mock_now
+            mock_datetime.combine = datetime.combine
+            
+            # Mock the timedelta class within the datetime module
+            mock_datetime.timedelta = timedelta
+            
+            next_reminder = scheduler._get_next_reminder_time()
+            
+            expected = datetime(2024, 1, 16, 18, 0, 0)  # Tomorrow at 6 PM
+            assert next_reminder == expected
+
+    @pytest.mark.asyncio
+    async def test_send_daily_reminders_success(self, scheduler, mock_callback):
+        """Test successful sending of daily reminders"""
+        await scheduler._send_daily_reminders()
+        
+        mock_callback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_daily_reminders_exception(self, scheduler, mock_callback):
+        """Test handling exception during reminder sending"""
+        mock_callback.side_effect = Exception("Test error")
+        
+        # Should not raise exception
+        await scheduler._send_daily_reminders()
+        
+        mock_callback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_schedule_loop_single_iteration(self, scheduler, mock_callback):
+        """Test single iteration of schedule loop"""
+        # Mock sleep to avoid long waits
+        with patch('asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+            # Mock _get_next_reminder_time to return near future
+            with patch.object(scheduler, '_get_next_reminder_time') as mock_next_time:
+                mock_now = datetime.now()
+                mock_next_time.return_value = mock_now + timedelta(seconds=1)
+                
+                # Start scheduler
+                scheduler.is_running = True
+                
+                # Create task but stop it quickly
+                task = asyncio.create_task(scheduler._schedule_loop())
+                
+                # Wait a bit then stop
+                await asyncio.sleep(0.1)
+                scheduler.is_running = False
+                
+                # Cancel and wait for completion
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                
+                # Should have called sleep
+                mock_sleep.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_schedule_loop_exception_handling(self, scheduler):
+        """Test exception handling in schedule loop"""
+        with patch.object(scheduler, '_get_next_reminder_time', side_effect=Exception("Test error")):
+            with patch('asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+                scheduler.is_running = True
+                
+                # Create task but stop it quickly
+                task = asyncio.create_task(scheduler._schedule_loop())
+                
+                # Wait a bit then stop
+                await asyncio.sleep(0.1)
+                scheduler.is_running = False
+                
+                # Cancel and wait for completion
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                
+                # Should have slept for error recovery
+                mock_sleep.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_schedule_loop_cancellation(self, scheduler):
+        """Test proper cancellation handling in schedule loop"""
+        scheduler.is_running = True
+        
+        # Start the loop
+        task = asyncio.create_task(scheduler._schedule_loop())
+        
+        # Cancel immediately
+        task.cancel()
+        
+        # Should handle CancelledError gracefully
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+class TestReminderSchedulerIntegration:
+    """Integration tests for ReminderScheduler"""
+
+    @pytest.mark.asyncio
+    async def test_scheduler_lifecycle(self):
+        """Test complete scheduler lifecycle"""
+        callback_called = False
+        
+        async def test_callback():
+            nonlocal callback_called
+            callback_called = True
+        
+        scheduler = ReminderScheduler(test_callback)
+        
+        # Start
+        await scheduler.start()
+        assert scheduler.is_running is True
+        
+        # Stop
+        await scheduler.stop()
+        assert scheduler.is_running is False
+
+    @pytest.mark.asyncio
+    async def test_multiple_start_stop_cycles(self):
+        """Test multiple start/stop cycles"""
+        callback = AsyncMock()
+        scheduler = ReminderScheduler(callback)
+        
+        # Multiple cycles
+        for _ in range(3):
+            await scheduler.start()
+            assert scheduler.is_running is True
+            
+            await scheduler.stop()
+            assert scheduler.is_running is False
+
+    @pytest.mark.asyncio
+    async def test_scheduler_with_immediate_reminder_time(self):
+        """Test scheduler when reminder time is immediate"""
+        callback = AsyncMock()
+        scheduler = ReminderScheduler(callback)
+        
+        # Mock time to be exactly reminder time
+        with patch('src.core.scheduler.reminder_scheduler.datetime') as mock_datetime:
+            mock_now = datetime(2024, 1, 15, 18, 0, 0)  # Exactly 6 PM
+            mock_datetime.now.return_value = mock_now
+            mock_datetime.combine = datetime.combine
+            
+            # Mock the timedelta class within the datetime module
+            mock_datetime.timedelta = timedelta
+            
+            next_reminder = scheduler._get_next_reminder_time()
+            
+            # Should schedule for tomorrow since current time >= reminder time
+            expected = datetime(2024, 1, 16, 18, 0, 0)
+            assert next_reminder == expected

--- a/tests/test_reminder_scheduler.py
+++ b/tests/test_reminder_scheduler.py
@@ -3,9 +3,11 @@ Test cases for the ReminderScheduler functionality
 """
 
 import asyncio
-import pytest
+import contextlib
 from datetime import datetime, time, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from src.core.scheduler.reminder_scheduler import ReminderScheduler
 
@@ -26,7 +28,7 @@ class TestReminderScheduler:
     def test_reminder_scheduler_initialization(self, mock_callback):
         """Test ReminderScheduler initialization"""
         scheduler = ReminderScheduler(mock_callback)
-        
+
         assert scheduler.send_reminder_callback == mock_callback
         assert scheduler.is_running is False
         assert scheduler.task is None
@@ -36,14 +38,14 @@ class TestReminderScheduler:
     async def test_start_scheduler(self, scheduler):
         """Test starting the reminder scheduler"""
         assert scheduler.is_running is False
-        
+
         # Start scheduler
         await scheduler.start()
-        
+
         assert scheduler.is_running is True
         assert scheduler.task is not None
         assert not scheduler.task.done()
-        
+
         # Clean up
         await scheduler.stop()
 
@@ -53,10 +55,10 @@ class TestReminderScheduler:
         # Start first
         await scheduler.start()
         assert scheduler.is_running is True
-        
+
         # Stop
         await scheduler.stop()
-        
+
         assert scheduler.is_running is False
         # Task should be cancelled
         if scheduler.task:
@@ -66,13 +68,13 @@ class TestReminderScheduler:
     async def test_start_already_running_scheduler(self, scheduler):
         """Test starting scheduler when already running"""
         await scheduler.start()
-        
+
         # Try to start again
         await scheduler.start()
-        
+
         # Should still be running
         assert scheduler.is_running is True
-        
+
         # Clean up
         await scheduler.stop()
 
@@ -80,38 +82,38 @@ class TestReminderScheduler:
     async def test_stop_not_running_scheduler(self, scheduler):
         """Test stopping scheduler when not running"""
         assert scheduler.is_running is False
-        
+
         # Should not raise exception
         await scheduler.stop()
-        
+
         assert scheduler.is_running is False
 
     def test_get_next_reminder_time_today(self, scheduler):
         """Test getting next reminder time when today's time hasn't passed"""
         # Mock current time to be 17:00 (before 18:00)
-        with patch('src.core.scheduler.reminder_scheduler.datetime') as mock_datetime:
+        with patch("src.core.scheduler.reminder_scheduler.datetime") as mock_datetime:
             mock_now = datetime(2024, 1, 15, 17, 0, 0)  # 5 PM
             mock_datetime.now.return_value = mock_now
             mock_datetime.combine = datetime.combine
-            
+
             next_reminder = scheduler._get_next_reminder_time()
-            
+
             expected = datetime(2024, 1, 15, 18, 0, 0)  # Today at 6 PM
             assert next_reminder == expected
 
     def test_get_next_reminder_time_tomorrow(self, scheduler):
         """Test getting next reminder time when today's time has passed"""
         # Mock current time to be 19:00 (after 18:00)
-        with patch('src.core.scheduler.reminder_scheduler.datetime') as mock_datetime:
+        with patch("src.core.scheduler.reminder_scheduler.datetime") as mock_datetime:
             mock_now = datetime(2024, 1, 15, 19, 0, 0)  # 7 PM
             mock_datetime.now.return_value = mock_now
             mock_datetime.combine = datetime.combine
-            
+
             # Mock the timedelta class within the datetime module
             mock_datetime.timedelta = timedelta
-            
+
             next_reminder = scheduler._get_next_reminder_time()
-            
+
             expected = datetime(2024, 1, 16, 18, 0, 0)  # Tomorrow at 6 PM
             assert next_reminder == expected
 
@@ -119,70 +121,68 @@ class TestReminderScheduler:
     async def test_send_daily_reminders_success(self, scheduler, mock_callback):
         """Test successful sending of daily reminders"""
         await scheduler._send_daily_reminders()
-        
+
         mock_callback.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_send_daily_reminders_exception(self, scheduler, mock_callback):
         """Test handling exception during reminder sending"""
         mock_callback.side_effect = Exception("Test error")
-        
+
         # Should not raise exception
         await scheduler._send_daily_reminders()
-        
+
         mock_callback.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_schedule_loop_single_iteration(self, scheduler, mock_callback):
         """Test single iteration of schedule loop"""
         # Mock sleep to avoid long waits
-        with patch('asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             # Mock _get_next_reminder_time to return near future
-            with patch.object(scheduler, '_get_next_reminder_time') as mock_next_time:
+            with patch.object(scheduler, "_get_next_reminder_time") as mock_next_time:
                 mock_now = datetime.now()
                 mock_next_time.return_value = mock_now + timedelta(seconds=1)
-                
+
                 # Start scheduler
                 scheduler.is_running = True
-                
+
                 # Create task but stop it quickly
                 task = asyncio.create_task(scheduler._schedule_loop())
-                
+
                 # Wait a bit then stop
                 await asyncio.sleep(0.1)
                 scheduler.is_running = False
-                
+
                 # Cancel and wait for completion
                 task.cancel()
-                try:
+                with contextlib.suppress(asyncio.CancelledError):
                     await task
-                except asyncio.CancelledError:
-                    pass
-                
+
                 # Should have called sleep
                 mock_sleep.assert_called()
 
     @pytest.mark.asyncio
     async def test_schedule_loop_exception_handling(self, scheduler):
         """Test exception handling in schedule loop"""
-        with patch.object(scheduler, '_get_next_reminder_time', side_effect=Exception("Test error")):
-            with patch('asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+        with patch.object(
+            scheduler, "_get_next_reminder_time", side_effect=Exception("Test error")
+        ):
+            with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
                 scheduler.is_running = True
-                
+
                 # Create task but stop it quickly
                 task = asyncio.create_task(scheduler._schedule_loop())
-                
+
                 # Wait a bit then stop
                 await asyncio.sleep(0.1)
                 scheduler.is_running = False
-                
+
                 # Cancel and wait for completion
                 task.cancel()
-                try:
+                with contextlib.suppress(asyncio.CancelledError):
                     await task
-                except asyncio.CancelledError:
-                    pass
-                
+
                 # Should have slept for error recovery
                 mock_sleep.assert_called()
 
@@ -190,13 +190,13 @@ class TestReminderScheduler:
     async def test_schedule_loop_cancellation(self, scheduler):
         """Test proper cancellation handling in schedule loop"""
         scheduler.is_running = True
-        
+
         # Start the loop
         task = asyncio.create_task(scheduler._schedule_loop())
-        
+
         # Cancel immediately
         task.cancel()
-        
+
         # Should handle CancelledError gracefully
         with pytest.raises(asyncio.CancelledError):
             await task
@@ -209,17 +209,17 @@ class TestReminderSchedulerIntegration:
     async def test_scheduler_lifecycle(self):
         """Test complete scheduler lifecycle"""
         callback_called = False
-        
+
         async def test_callback():
             nonlocal callback_called
             callback_called = True
-        
+
         scheduler = ReminderScheduler(test_callback)
-        
+
         # Start
         await scheduler.start()
         assert scheduler.is_running is True
-        
+
         # Stop
         await scheduler.stop()
         assert scheduler.is_running is False
@@ -229,12 +229,12 @@ class TestReminderSchedulerIntegration:
         """Test multiple start/stop cycles"""
         callback = AsyncMock()
         scheduler = ReminderScheduler(callback)
-        
+
         # Multiple cycles
         for _ in range(3):
             await scheduler.start()
             assert scheduler.is_running is True
-            
+
             await scheduler.stop()
             assert scheduler.is_running is False
 
@@ -243,18 +243,18 @@ class TestReminderSchedulerIntegration:
         """Test scheduler when reminder time is immediate"""
         callback = AsyncMock()
         scheduler = ReminderScheduler(callback)
-        
+
         # Mock time to be exactly reminder time
-        with patch('src.core.scheduler.reminder_scheduler.datetime') as mock_datetime:
+        with patch("src.core.scheduler.reminder_scheduler.datetime") as mock_datetime:
             mock_now = datetime(2024, 1, 15, 18, 0, 0)  # Exactly 6 PM
             mock_datetime.now.return_value = mock_now
             mock_datetime.combine = datetime.combine
-            
+
             # Mock the timedelta class within the datetime module
             mock_datetime.timedelta = timedelta
-            
+
             next_reminder = scheduler._get_next_reminder_time()
-            
+
             # Should schedule for tomorrow since current time >= reminder time
             expected = datetime(2024, 1, 16, 18, 0, 0)
             assert next_reminder == expected


### PR DESCRIPTION
## Summary
- Add automated daily reminders to encourage regular study sessions
- Send notifications at 18:00 (6 PM) to all active users
- Include motivational message with direct link to /study command

## Changes
- ✅ Created `ReminderScheduler` class for managing scheduled tasks
- ✅ Added `get_all_active_users()` method to retrieve all active users
- ✅ Integrated scheduler into BotHandler lifecycle
- ✅ Implemented `_send_daily_reminders()` method with error handling
- ✅ Added comprehensive test coverage (28 new tests)

## Test plan
- [x] Unit tests for ReminderScheduler
- [x] Tests for get_all_active_users functionality
- [x] Tests for daily reminder sending logic
- [x] Integration tests for bot lifecycle
- [x] All existing tests still pass (361 total)

## Notes
- Reminders are sent at 18:00 local server time
- Failed sends are logged but don't block other users
- Scheduler starts/stops with bot lifecycle
- No configuration required - works out of the box

🤖 Generated with [Claude Code](https://claude.ai/code)