### PR TITLE
Fix stats accuracy, improve word-quality prompts, add study rubrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,65 @@ SQLite database with four main tables:
 - **Async Operations**: All bot operations use async/await patterns
 - **Graceful Shutdown**: Bot handles shutdown signals and cleanup properly
 
+## Adding a New Bot Feature (Checklist)
+
+When adding a new study command / filter / rubric (anything like `/study_*`),
+always touch the full standard flow, not just the DB query — it's easy to
+ship a command that works in isolation but is unreachable or undocumented:
+
+1. **Repository method** (`src/core/database/repositories/*.py`) — the raw
+   SQL query.
+2. **`DatabaseManager` wrapper** (`src/core/database/database_manager.py`) —
+   thin pass-through, matches the pattern of existing `get_*` methods.
+3. **`CommandHandlers` method** (`src/core/handlers/command_handlers.py`) —
+   prefer flat, argument-free commands (`/study_nouns`, `/study_a1`, ...)
+   over one command taking a variant as `context.args` — the user explicitly
+   rejected the arg-based design ("не нравится что команды надо еще както
+   выбирать хочу плоские команды"), so a family of variants gets a thin
+   command method per variant delegating to a shared private helper (see
+   `_study_pos` / `_study_level` and their `study_nouns_command` /
+   `study_a1_command` etc. wrappers). Each guards on
+   `update.effective_user`, looks up `db_user`, replies with
+   `ReplyKeyboardRemove()` on every branch, and handles the empty-results
+   case with its own message.
+4. **Register the command** in `src/bot_handler.py`:
+   - `CommandHandler(...)` in `_add_handlers` (wrapped in
+     `self.require_authorization(...)`)
+   - `BotCommand(...)` entry in `setup_bot_menu` — a command that isn't in
+     this list won't show in the Telegram UI even if it works when typed.
+5. **Update `/help` text** in `command_handlers.py` (`help_command`) — same
+   omission risk as the menu entry.
+6. **Schema changes**, if any, go in
+   `src/core/database/connection.py::_run_migrations`, guarded by
+   `PRAGMA table_info(...)` checks (see the `level`/`confidence` column
+   pattern) — never a manual `ALTER TABLE` run by hand against the live DB.
+7. **OpenAI prompt changes**, if the new feature needs a new field from the
+   model, go in both `_get_system_prompt` and `_get_batch_system_prompt` in
+   `src/word_processor.py` — the two prompts drift apart easily if only one
+   is updated.
+
+### Test coverage checklist per command handler
+
+Each new `*_command` needs its own `tests/test_*_feature.py` covering, at
+minimum (mirror `tests/test_study_pos_feature.py` /
+`tests/test_study_level_feature.py`):
+- happy path (valid input → correct `db_manager` call + `_start_study_session`
+  called)
+- missing/invalid argument (if the command takes one) → helpful message, no
+  DB call
+- `db_user` not found → "❌ Пользователь не найден" message
+- empty result set from the DB → its own "nothing to study" message
+- `update.effective_user is None` → early return, no DB calls at all
+
+### Before calling any feature done
+
+- `make lint` (ruff + mypy) must be clean.
+- Run the FULL suite (`uv run pytest tests/ -q`), not just the new test
+  file, and diff the pass/fail/error counts against a clean run on `main`
+  (`git stash` + rerun) — a fixed baseline of pre-existing failures/errors
+  exists (missing env vars in test config, unrelated to app code). The bar
+  is "no NEW failures", not "zero failures".
+
 ## Memories
 
 ### Database Best Practices

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ make run
   have one)
 - `/study_common_verbs` - Study from a curated list of the most frequent
   German verbs, intersected with your own vocabulary
+- `/study_question_words` - Study German question words (Fragewörter: wer,
+  was, wo, wann, warum, wie...), intersected with your own vocabulary
+- `/study_modal_verbs` - Study the core German modal verbs (können, müssen,
+  dürfen, sollen, wollen, mögen, möchten), intersected with your own
+  vocabulary
 - `/stats` - Show learning statistics (total/new/due words, words added
   today, study streak, correct/incorrect reviews)
 - `/settings` - Configure session settings

--- a/README.md
+++ b/README.md
@@ -51,10 +51,23 @@ make run
 
 - `/start` - Welcome and instructions
 - `/add <text>` - Add German words from text
-- `/study` - Start spaced repetition session
-- `/study_new` - Study only new words
-- `/study_difficult` - Review difficult words
-- `/stats` - Show learning statistics
+- `/study` - Study words due for review (SM2 schedule)
+- `/study_new` - Study only new words (never reviewed)
+- `/study_difficult` - Review difficult words (low easiness factor)
+- `/study_verbs`, `/study_nouns`, `/study_adjectives`, `/study_adverbs`,
+  `/study_pronouns`, `/study_prepositions`, `/study_conjunctions`,
+  `/study_numerals`, `/study_interjections` - Study only words of that part
+  of speech
+- `/study_recent [N]` - Study the last N added words (default 10, max 200),
+  regardless of due date
+- `/study_a1`, `/study_a2`, `/study_b1`, `/study_b2`, `/study_c1`,
+  `/study_c2` - Study words tagged with that CEFR level (level is assigned
+  automatically by OpenAI for words added going forward; older words may not
+  have one)
+- `/study_common_verbs` - Study from a curated list of the most frequent
+  German verbs, intersected with your own vocabulary
+- `/stats` - Show learning statistics (total/new/due words, words added
+  today, study streak, correct/incorrect reviews)
 - `/settings` - Configure session settings
 - `/help` - Command help
 

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -273,7 +273,14 @@ Status: **implemented (level rubric + common-verbs rubric)**
   (`WordRepository.get_words_by_lemma_set`). Deliberately NOT AI-generated
   per-word popularity, to avoid the same kind of hallucination risk found in
   item 4. Already argument-free, no redo needed.
+- `/study_question_words` and `/study_modal_verbs` — same curated-lemma-set
+  pattern as `/study_common_verbs` (`QUESTION_WORDS` / `MODAL_VERBS` in
+  `src/core/handlers/command_handlers.py`), added on request after user asked
+  "какие еще категории можно добавить?". No DB/schema/AI changes needed —
+  reuses `WordRepository.get_words_by_lemma_set`.
 - Tests: `tests/test_study_level_feature.py`.
 - Not done: arbitrary free-form topic tagging (e.g. "travel", "food") beyond
-  level + common-verbs — would need its own tagging scheme; not requested
-  with that level of detail, can be added later if wanted.
+  level + common-verbs/question-words/modal-verbs — would need its own
+  tagging scheme (AI classification with the same hallucination risk as
+  item 4, or manual per-word curation that doesn't scale to 2000+ words);
+  not requested with that level of detail, can be added later if wanted.

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -1,0 +1,279 @@
+# Issues & Feature Requests
+
+Running list of user complaints and feature requests, dictated by the user and
+recorded by Claude. Each item: description, status, and (once investigated) root
+cause / fix plan.
+
+**Deployment note:** the live bot runs on `bgspwn-home-nas.tailba405.ts.net`
+(Synology NAS), container `german-bot`, project dir
+`/volume1/docker/anki-bot/`, DB at `/volume1/docker/anki-bot/data/bot.db`
+(`docker compose -f docker-compose.prod.yml`, docker binary at
+`/usr/local/bin/docker`). The `do-fra1` host also has an old copy of this
+project (`/root/projects/anki-bot/`) but its `german-bot` container doesn't
+exist there and its DB hasn't been touched since 2026-03-23 — it's a stale/
+abandoned deployment, not the live one. Don't use it for investigation.
+
+## 1. Statistics are calculated incorrectly
+
+Status: **root cause found**
+
+`/stats` shows wrong/missing numbers: words added, filtered, correct/incorrect
+review counts.
+
+Confirmed in code (`src/core/database/repositories/user_repository.py:183-185`):
+
+```python
+# Calculate study streak (simplified)
+stats["study_streak"] = 0  # Would need more complex logic
+stats["words_today"] = 0  # Would need to track word additions
+```
+
+- `words_today` (words added today) is hardcoded to `0` — never actually queried.
+- `study_streak` is hardcoded to `0` — never actually computed.
+- `format_progress_stats` (`src/utils.py:67`) only prints `total_words`,
+  `due_words`, `new_words`, `average_accuracy` — no correct/incorrect review
+  counts, no "filtered" (skipped/rejected) word count anywhere in `/stats`.
+- Filtered/skipped words (duplicates, non-German, parse failures) are only
+  reported in the one-off `/add` success message
+  (`src/bot_handler.py:444-462`), not in `/stats`.
+
+## 2. Study last N added words
+
+Status: **implemented**
+
+Added `/study_recent [N]` command (default 10, max 200) — studies the most
+recently added words ordered by `learning_progress.created_at DESC`,
+regardless of SM2 due date. New repo method `WordRepository.get_recent_words`
++ `DatabaseManager.get_recent_words`, handler
+`CommandHandlers.study_recent_command`
+(`src/core/handlers/command_handlers.py`), registered in `src/bot_handler.py`
+and bot command menu. Tests: `tests/test_study_recent_feature.py`.
+
+## 3. Translation/example quality
+
+Status: **root cause found, prompt fix applied, model switch pending your
+action** — checked against the **live** production DB on
+`bgspwn-home-nas.tailba405.ts.net` (2033 words as of 2026-07-29).
+
+Root cause candidate #1 — cheap model (still live, needs your action):
+
+```
+# /volume1/docker/anki-bot/.env on bgspwn-home-nas
+OPENAI_MODEL=gpt-4.1-nano-2025-04-14
+```
+
+`nano` is OpenAI's smallest/cheapest tier, not suited for nuanced linguistic
+analysis (idioms, polysemy, article edge cases). This is the most likely
+driver of "wrong translation" complaints, more than the prompt itself.
+**Not changed — I don't edit `.env` files. See instructions below.**
+
+Root cause candidate #2 — system prompt had no guardrails. **Fixed** in
+`src/word_processor.py` (`_get_system_prompt` / `_get_batch_system_prompt`):
+added explicit rules forbidding the translation from echoing the German word
+and forbidding Russian text inside the example sentence. Evidence that
+prompted the fix (11/2033 = 0.5% of all words, 2/471 = 0.4% of words added
+since March, so it's rare but ongoing, not fully fixed by an earlier prompt
+version as previously assumed):
+
+- Lemma leaked into translation: `Vegetation` → `" Vegetation"` (not
+  translated at all), `sichern` → `"обеспечивать, sichern — охранять,
+  закреплять"`, `Rechnung` → `"Счёт, Rechnung"`, `Weiterbildung` →
+  `"повышение квалификации, Weiterbildung"`, and 7 more.
+- 8 very early rows (ids 203-217) have the Russian translation stuffed into
+  the `example` field in parentheses, e.g. `"Ich bin immer pünktlich. (Я
+  всегда пунктуален.)"` — none found in recent additions, so this specific
+  pattern does look fixed already (unrelated to today's prompt change).
+
+**Action needed from you** — I won't touch `.env`. On
+`bgspwn-home-nas.tailba405.ts.net`, edit
+`/volume1/docker/anki-bot/.env` and change:
+
+```
+OPENAI_MODEL=gpt-4.1-mini
+```
+
+then restart:
+
+```
+/usr/local/bin/docker compose -f /volume1/docker/anki-bot/docker-compose.prod.yml up -d
+```
+
+I can run the restart for you once you've made the `.env` change — just ask.
+
+## 4. Data audit: bad lemma forms, wrong translations, wrong examples
+
+Status: **list compiled, fixes NOT yet applied — awaiting your decision on the
+delete-vs-fix items below**
+
+Audited the live DB (2033 words) with targeted SQL heuristics (non-infinitive
+verb lemmas, lowercase nouns, non-Cyrillic translations, examples not
+containing the lemma, duplicated examples, self-flagged part-of-speech
+values), then manually verified every candidate. This is not a 100%
+line-by-line read of all 2033 rows — it's heuristic-guided, so some subtle
+mistranslations may still be missed.
+
+### A. Junk entries — not real words, propose **deleting** (needs your OK,
+removes the word + its learning history)
+
+| id | lemma | why |
+|---|---|---|
+| 429 | `der/das` | AI self-tagged part_of_speech as "incorrect form" |
+| 432 | `der/die` | same, self-tagged "incorrect form" |
+| 804 | `verb` | literal placeholder entry, translation "глаголы" |
+| 931 | `ga` | AI's own example field literally says "Нет корректного примера" |
+| 1698 | `txt` | file extension, not a German word |
+
+### B. Broken/fragment entries — fixable by correcting the lemma (keeps
+learning history)
+
+| id | current lemma | fix to | why |
+|---|---|---|---|
+| 899 | *(empty)* | `kennenlernen` | lemma is blank; translation/example clearly point to colloquial "kennenlernen" |
+| 871 | `fu` | `pfui` | AI self-tagged "not a standard word, possibly a typo"; translation "фу" matches German interjection `pfui` |
+| 1754 | `zanzen` | `Zähne` | not a real German word; translation "зубы" (teeth) = `Zähne` |
+| 1751 | `düsterstraße` | delete or keep? | ad-hoc invented compound ("dark street"), not a dictionary word — your call |
+
+### C. Wrong case / non-base lemma form (fixable, capitalization or
+infinitive)
+
+| id | current | fix to |
+|---|---|---|
+| 1465 | `einhaltung` (verb) | `Einhaltung` (noun) |
+| 1903 | `festgestellt` (Partizip II) | `feststellen` (infinitive) |
+| 632 | `liebling` | `Liebling` |
+| 904 | `splitter` | `Splitter` (see also C below — translation/example also wrong) |
+| 1225 | `mitte` | `Mitte` |
+| 197 | `morgen` | conflates adverb "tomorrow" + noun "morning" in one lowercase entry — needs splitting or picking one sense |
+| 602 | `angestellt` | tagged both adjective and verb; as verb should be `anstellen` |
+
+### D. Wrong translation (confirmed factually incorrect)
+
+| id | lemma | current translation | should be |
+|---|---|---|---|
+| 250 | `fallen` (падать) | `нравится` | `падать` — this is the meaning of `gefallen`, a different verb |
+| 465 | `Rock` (юбка) | `рок, камень` | `юбка` — got confused with English "rock" |
+| 783 | `Gesicht` | `脸` | `лицо` — translated into **Chinese**, not Russian |
+| 904 | `splitter`/`Splitter` | `камертоны... (музыкальных инструментов)` ("tuning forks") | `осколок, щепка` |
+| 1983 | `Geschenkpapier` | `gift wrap` | `подарочная бумага` — translated into **English**, not Russian |
+
+### E. Wrong/broken example sentence
+
+| id | lemma | current example | problem |
+|---|---|---|---|
+| 250 | `fallen` | `Das Bild gefällt mir sehr.` | example is for `gefallen`, doesn't use `fallen` at all (duplicate of id 1147's example) |
+| 465 | `Rock` | `Der Felsen ist sehr groß.` | doesn't mention `Rock` at all, talks about a cliff |
+| 904 | `splitter` | `Die Musiker stimmen ihre Späne.` | uses wrong word `Späne`, nonsensical sentence |
+| 1225 | `mitte` | `Im mitten der Stadt gibt es einen Park.` | ungrammatical, should be `In der Mitte der Stadt...` |
+| 1781 | `abstatten` | `Der König statten dem Land einen Besuch ab.` | subject-verb agreement error, should be `stattet` |
+| 1884 | `bestimmt` | `Der certain Bescheid ist für die Reise erforderlich.` | stray English word `certain` inside a German sentence |
+| 1959 | `Nahrungsmittel` | `Lebensmittel sind lebenswichtig.` | uses synonym `Lebensmittel`, never actually uses `Nahrungsmittel` |
+| 931 | `ga` | *(see A — self-admitted no example)* | — |
+
+### Also flagged, not clearly a bug — your call
+
+- **Prepositional-contraction "words"**: ids 4, 10, 202, 596, 751, 851, 861,
+  863, 921, 962, 1171, 1174, 1688, 1733, 1786 (`zu+dem`, `an das`, `bei dem`,
+  `von dem`, etc.) — the bot created standalone vocabulary cards for
+  preposition+article combinations, some with a broken `+` syntax (`zu+dem`
+  instead of `zudem`/`zum`). Might be intentional (drilling case government)
+  or might be text-parser noise from sentences like "Ich gehe zum Arzt" being
+  split wrong. Worth deciding whether this category should exist at all.
+- ids 811 / 1743: two duplicate `sie` entries with garbage lemmas
+  (`sie (они в дательном падеже)`, `sie (Pronomen, Dativ)`) instead of a clean
+  pronoun form — likely both should be merged/removed since `sie` is probably
+  already a separate clean entry elsewhere.
+- Nationality adjectives tagged as noun too (`rumänisch`, `türkisch`,
+  `ungarisch`) — fine lowercase as adjectives, but the "noun" tag is
+  misleading since the noun sense needs a different capitalized word.
+
+### Proposed process once you confirm scope
+1. `sqlite3` backup of `bot.db` on the NAS before any write.
+2. Apply category B/C/D fixes as `UPDATE` statements (~15 rows, low risk,
+   keeps learning history).
+3. For category A/grey-area items, apply your delete/keep decision.
+4. Re-run the same audit queries after to confirm zero regressions.
+
+**Decisions (confirmed by user 2026-07-30):** delete all of category A
+(429, 432, 804, 931, 1698), delete 1751 (`düsterstraße`), fix the category B
+fragments instead of deleting (899→`kennenlernen`, 871→`fu`→`pfui`,
+1754→`zanzen`→`Zahn`), delete all 15 prepositional-contraction entries, delete
+the 2 duplicate malformed `sie` entries (811, 1743). Category C/D/E factual
+fixes applied as proposed.
+
+**Executed 2026-07-30** on the live NAS DB (backup taken first:
+`/volume1/docker/anki-bot/data/bot.db.bak_20260730_090040`):
+- Deleted 23 junk/contraction/duplicate entries + their `learning_progress` /
+  `review_history` rows.
+- Applied 14 `UPDATE` fixes for category C/D/E.
+- 3 of the planned "fix the lemma" fragment fixes (899→`kennenlernen`,
+  1754→`Zahn`, 1903→`feststellen`) hit `UNIQUE constraint failed: words.lemma`
+  — turned out each one was a genuine near-duplicate of an *already-existing*
+  clean entry the model had created earlier under a different surface form
+  (id 218 `kennenlernen`, id 801 `Zahn`, id 1057 `feststellen`). Deleted the 3
+  duplicates instead of renaming them.
+- Word count: 2033 → 2007.
+
+**Root cause of those 3 duplicates — checked the code, not a dedup bug:**
+`WordRepository.add_words_to_user` (`src/core/database/repositories/word_repository.py:300-305`)
+already does a case-insensitive check against the whole `words` table
+(`WHERE LOWER(lemma) = LOWER(?)`) before inserting, and `words.lemma` has a
+`UNIQUE` constraint — exact re-adds are correctly blocked. The duplicates
+happened because OpenAI returned a *different surface form* for the same
+underlying word on different occasions (infinitive vs. participle, a
+hallucinated wrong word, or a blank lemma) — different strings can't be
+caught by exact/case-insensitive matching. Fixed by adding explicit
+lemma-canonicalization rules to both system prompts in
+`src/word_processor.py` (`_get_system_prompt` / `_get_batch_system_prompt`):
+lemma must always be infinitive/singular-nominative-capitalized/base form,
+must never be empty, `part_of_speech` must be a single clean value from a
+fixed list, and preposition+article contractions must never be treated as
+standalone words. This won't fix already-stored bad rows but should stop new
+ones of this kind.
+
+## 5. Study by part of speech
+
+Status: **implemented**
+
+First cut used an arg-based `/study_pos <part_of_speech>`. User explicitly
+disliked having to pick a value ("не нравится что команды надо еще както
+выбирать хочу плоские команды") — redone as flat, argument-free commands
+matching the existing `/study_verbs` pattern: `/study_nouns`,
+`/study_adjectives`, `/study_adverbs`, `/study_pronouns`,
+`/study_prepositions`, `/study_conjunctions`, `/study_numerals`,
+`/study_interjections`. Each is a thin wrapper around a shared
+`CommandHandlers._study_pos(update, context, part_of_speech)` helper.
+Matches `LOWER(part_of_speech) LIKE LOWER(?) || '%'` (prefix match) so
+multi-tagged values like "adjective/verb (Partizip II)" are still found
+under "adjective". New repo method
+`WordRepository.get_words_by_part_of_speech` +
+`DatabaseManager.get_words_by_part_of_speech`. Tests:
+`tests/test_study_pos_feature.py`.
+
+## 6. Topic/category-based study ("rubrics")
+
+Status: **implemented (level rubric + common-verbs rubric)**
+
+- Added a `level` column to `words` (migration in
+  `src/core/database/connection.py::_run_migrations`, runs automatically on
+  next bot startup — no manual DB surgery needed). OpenAI system prompts
+  (`src/word_processor.py`) now also return a CEFR level estimate
+  (A1/A2/B1/B2/C1/C2) for every newly processed word, stored end-to-end
+  (`ProcessedWord.level` → `words_data["level"]` in `bot_handler.py` →
+  `WordRepository.add_words_to_user`/`create_word`).
+- Same flat-command redo as item 5: `/study_a1`, `/study_a2`, `/study_b1`,
+  `/study_b2`, `/study_c1`, `/study_c2` (no argument), each a thin wrapper
+  around `CommandHandlers._study_level(update, context, level)`.
+  **Existing 2007 words have `level = NULL`** — this only tags words added
+  from now on; retroactively classifying old words would need a separate
+  bulk OpenAI pass over the whole DB (extra cost/time), not done here.
+- `/study_common_verbs` — a curated, hardcoded list of ~90 of the most
+  frequent German verbs (`COMMON_VERBS` in
+  `src/core/handlers/command_handlers.py`, standard DaF/Goethe-Institut
+  frequency list) intersected with the user's own words
+  (`WordRepository.get_words_by_lemma_set`). Deliberately NOT AI-generated
+  per-word popularity, to avoid the same kind of hallucination risk found in
+  item 4. Already argument-free, no redo needed.
+- Tests: `tests/test_study_level_feature.py`.
+- Not done: arbitrary free-form topic tagging (e.g. "travel", "food") beyond
+  level + common-verbs — would need its own tagging scheme; not requested
+  with that level of detail, can be added later if wanted.

--- a/src/bot_handler.py
+++ b/src/bot_handler.py
@@ -240,6 +240,112 @@ class BotHandler:
         )
         app.add_handler(
             CommandHandler(
+                "study_recent",
+                self.require_authorization(self.command_handlers.study_recent_command),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_nouns",
+                self.require_authorization(self.command_handlers.study_nouns_command),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_adjectives",
+                self.require_authorization(
+                    self.command_handlers.study_adjectives_command
+                ),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_adverbs",
+                self.require_authorization(self.command_handlers.study_adverbs_command),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_pronouns",
+                self.require_authorization(self.command_handlers.study_pronouns_command),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_prepositions",
+                self.require_authorization(
+                    self.command_handlers.study_prepositions_command
+                ),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_conjunctions",
+                self.require_authorization(
+                    self.command_handlers.study_conjunctions_command
+                ),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_numerals",
+                self.require_authorization(self.command_handlers.study_numerals_command),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_interjections",
+                self.require_authorization(
+                    self.command_handlers.study_interjections_command
+                ),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_a1",
+                self.require_authorization(self.command_handlers.study_a1_command),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_a2",
+                self.require_authorization(self.command_handlers.study_a2_command),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_b1",
+                self.require_authorization(self.command_handlers.study_b1_command),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_b2",
+                self.require_authorization(self.command_handlers.study_b2_command),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_c1",
+                self.require_authorization(self.command_handlers.study_c1_command),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_c2",
+                self.require_authorization(self.command_handlers.study_c2_command),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_common_verbs",
+                self.require_authorization(
+                    self.command_handlers.study_common_verbs_command
+                ),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
                 "stats", self.require_authorization(self.command_handlers.stats_command)
             )
         )
@@ -279,6 +385,22 @@ class BotHandler:
             BotCommand("study_new", "🆕 Изучать только новые слова"),
             BotCommand("study_difficult", "🔥 Повторить сложные слова"),
             BotCommand("study_verbs", "🔤 Изучать только глаголы"),
+            BotCommand("study_recent", "🕐 Изучать последние N добавленных слов"),
+            BotCommand("study_nouns", "🧩 Только существительные"),
+            BotCommand("study_adjectives", "🧩 Только прилагательные"),
+            BotCommand("study_adverbs", "🧩 Только наречия"),
+            BotCommand("study_pronouns", "🧩 Только местоимения"),
+            BotCommand("study_prepositions", "🧩 Только предлоги"),
+            BotCommand("study_conjunctions", "🧩 Только союзы"),
+            BotCommand("study_numerals", "🧩 Только числительные"),
+            BotCommand("study_interjections", "🧩 Только междометия"),
+            BotCommand("study_a1", "🎓 Слова уровня A1"),
+            BotCommand("study_a2", "🎓 Слова уровня A2"),
+            BotCommand("study_b1", "🎓 Слова уровня B1"),
+            BotCommand("study_b2", "🎓 Слова уровня B2"),
+            BotCommand("study_c1", "🎓 Слова уровня C1"),
+            BotCommand("study_c2", "🎓 Слова уровня C2"),
+            BotCommand("study_common_verbs", "⭐ Популярные глаголы"),
             BotCommand("stats", "📊 Показать статистику"),
             BotCommand("help", "❓ Справка по командам"),
             BotCommand("settings", "⚙️ Настройки бота"),
@@ -405,6 +527,7 @@ class BotHandler:
                                 "example": pw.example,
                                 "additional_forms": pw.additional_forms,
                                 "confidence": pw.confidence,
+                                "level": pw.level,
                             }
                         )
 

--- a/src/bot_handler.py
+++ b/src/bot_handler.py
@@ -346,6 +346,22 @@ class BotHandler:
         )
         app.add_handler(
             CommandHandler(
+                "study_question_words",
+                self.require_authorization(
+                    self.command_handlers.study_question_words_command
+                ),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
+                "study_modal_verbs",
+                self.require_authorization(
+                    self.command_handlers.study_modal_verbs_command
+                ),
+            )
+        )
+        app.add_handler(
+            CommandHandler(
                 "stats", self.require_authorization(self.command_handlers.stats_command)
             )
         )
@@ -401,6 +417,8 @@ class BotHandler:
             BotCommand("study_c1", "🎓 Слова уровня C1"),
             BotCommand("study_c2", "🎓 Слова уровня C2"),
             BotCommand("study_common_verbs", "⭐ Популярные глаголы"),
+            BotCommand("study_question_words", "❓ Вопросительные слова"),
+            BotCommand("study_modal_verbs", "🔧 Модальные глаголы"),
             BotCommand("stats", "📊 Показать статистику"),
             BotCommand("help", "❓ Справка по командам"),
             BotCommand("settings", "⚙️ Настройки бота"),

--- a/src/core/database/connection.py
+++ b/src/core/database/connection.py
@@ -147,6 +147,7 @@ class DatabaseConnection:
                 example TEXT NOT NULL,
                 additional_forms TEXT,
                 confidence REAL DEFAULT 1.0,
+                level TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
@@ -272,6 +273,12 @@ class DatabaseConnection:
                 conn.commit()
                 logger.info("Successfully added confidence column to words table")
 
+            if "level" not in columns:
+                logger.info("Adding missing level column to words table")
+                conn.execute("ALTER TABLE words ADD COLUMN level TEXT")
+                conn.commit()
+                logger.info("Successfully added level column to words table")
+
             # Check if response_time_ms column exists in review_history table
             cursor = conn.execute("PRAGMA table_info(review_history)")
             review_table_info = cursor.fetchall()
@@ -308,6 +315,7 @@ class DatabaseConnection:
                         example TEXT NOT NULL,
                         additional_forms TEXT,
                         confidence REAL DEFAULT 1.0,
+                        level TEXT,
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                     )
@@ -329,6 +337,11 @@ class DatabaseConnection:
                     "COALESCE(confidence, 1.0) as confidence",
                 ]
 
+                if "level" in old_columns:
+                    select_parts.append("level")
+                else:
+                    select_parts.append("NULL as level")
+
                 if "created_at" in old_columns:
                     select_parts.append("created_at")
                 else:
@@ -342,7 +355,7 @@ class DatabaseConnection:
                 select_query = f"""
                     INSERT INTO words_new (
                         id, lemma, part_of_speech, article, translation,
-                        example, additional_forms, confidence, created_at, updated_at
+                        example, additional_forms, confidence, level, created_at, updated_at
                     )
                     SELECT {", ".join(select_parts)}
                     FROM words

--- a/src/core/database/database_manager.py
+++ b/src/core/database/database_manager.py
@@ -115,6 +115,42 @@ class DatabaseManager:
         """Get verb words for study"""
         return self.word_repo.get_verb_words(telegram_id, limit, randomize)
 
+    def get_recent_words(
+        self, telegram_id: int, limit: int = 10
+    ) -> list[dict[str, Any]]:
+        """Get the most recently added words for study"""
+        return self.word_repo.get_recent_words(telegram_id, limit)
+
+    def get_words_by_part_of_speech(
+        self,
+        telegram_id: int,
+        part_of_speech: str,
+        limit: int = 10,
+        randomize: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Get words filtered by part of speech for study"""
+        return self.word_repo.get_words_by_part_of_speech(
+            telegram_id, part_of_speech, limit, randomize
+        )
+
+    def get_words_by_level(
+        self, telegram_id: int, level: str, limit: int = 10, randomize: bool = True
+    ) -> list[dict[str, Any]]:
+        """Get words filtered by CEFR level for study"""
+        return self.word_repo.get_words_by_level(telegram_id, level, limit, randomize)
+
+    def get_words_by_lemma_set(
+        self,
+        telegram_id: int,
+        lemmas: list[str],
+        limit: int = 10,
+        randomize: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Get user's words whose lemma is in a given set for study"""
+        return self.word_repo.get_words_by_lemma_set(
+            telegram_id, lemmas, limit, randomize
+        )
+
     def add_words_to_user(
         self, telegram_id: int, words_data: list[dict[str, Any]]
     ) -> int:

--- a/src/core/database/models.py
+++ b/src/core/database/models.py
@@ -29,6 +29,7 @@ class Word(TypedDict):
     example: str
     additional_forms: str | None
     confidence: float
+    level: str | None
     created_at: datetime
     updated_at: datetime
 
@@ -71,3 +72,5 @@ class UserStats(TypedDict):
     study_streak: int
     words_today: int
     reviews_today: int
+    correct_reviews: int
+    incorrect_reviews: int

--- a/src/core/database/repositories/user_repository.py
+++ b/src/core/database/repositories/user_repository.py
@@ -3,7 +3,7 @@ User repository for database operations
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from ..connection import DatabaseConnection
 from ..models import User, UserStats
@@ -136,7 +136,8 @@ class UserRepository:
                         SUM(CASE WHEN lp.repetitions = 0 THEN 1 ELSE 0 END) as new_words,
                         SUM(CASE WHEN datetime(lp.next_review_date) <= datetime('now', 'localtime') AND lp.repetitions > 0 THEN 1 ELSE 0 END) as due_words,
                         SUM(CASE WHEN lp.repetitions >= 3 THEN 1 ELSE 0 END) as learned_words,
-                        SUM(CASE WHEN lp.easiness_factor < 2.0 THEN 1 ELSE 0 END) as difficult_words
+                        SUM(CASE WHEN lp.easiness_factor < 2.0 THEN 1 ELSE 0 END) as difficult_words,
+                        SUM(CASE WHEN date(lp.created_at) = date('now', 'localtime') THEN 1 ELSE 0 END) as words_today
                     FROM learning_progress lp
                     WHERE lp.telegram_id = ?
                     """,
@@ -149,10 +150,13 @@ class UserRepository:
 
                 stats = dict(row)
 
-                # Get average accuracy from recent reviews
+                # Get review accuracy (correct/incorrect) from recent reviews
                 cursor = conn.execute(
                     """
-                    SELECT AVG(CASE WHEN rating >= 3 THEN 1.0 ELSE 0.0 END) as avg_accuracy
+                    SELECT
+                        COUNT(*) as total_reviews,
+                        SUM(CASE WHEN rating >= 3 THEN 1 ELSE 0 END) as correct_reviews,
+                        SUM(CASE WHEN rating < 3 THEN 1 ELSE 0 END) as incorrect_reviews
                     FROM review_history
                     WHERE telegram_id = ? AND reviewed_at >= datetime('now', '-30 days')
                     """,
@@ -160,9 +164,12 @@ class UserRepository:
                 )
 
                 accuracy_row = cursor.fetchone()
+                total_reviews = accuracy_row["total_reviews"] or 0
+                stats["correct_reviews"] = accuracy_row["correct_reviews"] or 0
+                stats["incorrect_reviews"] = accuracy_row["incorrect_reviews"] or 0
                 stats["average_accuracy"] = (
-                    accuracy_row["avg_accuracy"]
-                    if accuracy_row["avg_accuracy"]
+                    stats["correct_reviews"] / total_reviews
+                    if total_reviews
                     else 0.0
                 )
 
@@ -172,7 +179,7 @@ class UserRepository:
                     SELECT
                         COUNT(DISTINCT word_id) as reviews_today
                     FROM review_history
-                    WHERE telegram_id = ? AND date(reviewed_at) = date('now')
+                    WHERE telegram_id = ? AND date(reviewed_at, 'localtime') = date('now', 'localtime')
                     """,
                     (telegram_id,),
                 )
@@ -180,12 +187,42 @@ class UserRepository:
                 today_row = cursor.fetchone()
                 stats["reviews_today"] = today_row["reviews_today"] if today_row else 0
 
-                # Calculate study streak (simplified)
-                stats["study_streak"] = 0  # Would need more complex logic
-                stats["words_today"] = 0  # Would need to track word additions
+                # Calculate study streak: consecutive days (ending today or
+                # yesterday) with at least one review
+                cursor = conn.execute(
+                    """
+                    SELECT DISTINCT date(reviewed_at, 'localtime') as review_date
+                    FROM review_history
+                    WHERE telegram_id = ?
+                    """,
+                    (telegram_id,),
+                )
+                review_dates = {r["review_date"] for r in cursor.fetchall()}
+                stats["study_streak"] = self._calculate_streak(review_dates)
 
                 return stats
 
         except Exception as e:
             logger.error(f"Error getting user stats: {e}")
             return None
+
+    @staticmethod
+    def _calculate_streak(review_dates: set[str]) -> int:
+        """Count consecutive days with at least one review, walking back from today"""
+        if not review_dates:
+            return 0
+
+        today = datetime.now().date()
+        cursor_date = today
+        if cursor_date.isoformat() not in review_dates:
+            # No review today yet - streak can still continue from yesterday
+            cursor_date -= timedelta(days=1)
+            if cursor_date.isoformat() not in review_dates:
+                return 0
+
+        streak = 0
+        while cursor_date.isoformat() in review_dates:
+            streak += 1
+            cursor_date -= timedelta(days=1)
+
+        return streak

--- a/src/core/database/repositories/word_repository.py
+++ b/src/core/database/repositories/word_repository.py
@@ -25,9 +25,9 @@ class WordRepository:
                     """
                     INSERT INTO words (
                         lemma, part_of_speech, article, translation,
-                        example, additional_forms, confidence
+                        example, additional_forms, confidence, level
                     )
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         word_data.get("lemma"),
@@ -37,6 +37,7 @@ class WordRepository:
                         word_data.get("example"),
                         word_data.get("additional_forms"),
                         word_data.get("confidence", 1.0),
+                        word_data.get("level"),
                     ),
                 )
 
@@ -248,6 +249,127 @@ class WordRepository:
             logger.error(f"Error getting verb words: {e}")
             return []
 
+    def get_words_by_part_of_speech(
+        self,
+        telegram_id: int,
+        part_of_speech: str,
+        limit: int = 10,
+        randomize: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Get words filtered by part of speech (prefix match, e.g. 'noun' also
+        matches 'noun (informal)') for study"""
+        try:
+            with self.db_connection.get_connection() as conn:
+                order_clause = (
+                    "ORDER BY RANDOM()" if randomize else "ORDER BY lp.created_at ASC"
+                )
+
+                cursor = conn.execute(
+                    f"""
+                    SELECT w.*, lp.repetitions, lp.easiness_factor, lp.interval_days,
+                           lp.next_review_date, lp.last_reviewed
+                    FROM words w
+                    JOIN learning_progress lp ON w.id = lp.word_id
+                    WHERE lp.telegram_id = ? AND LOWER(w.part_of_speech) LIKE LOWER(?) || '%'
+                    {order_clause}
+                    LIMIT ?
+                    """,  # noqa: S608  # Safe: order_clause is from predefined strings
+                    (telegram_id, part_of_speech, limit),
+                )
+                return [dict(row) for row in cursor.fetchall()]
+        except Exception as e:
+            logger.error(f"Error getting words by part of speech: {e}")
+            return []
+
+    def get_words_by_level(
+        self,
+        telegram_id: int,
+        level: str,
+        limit: int = 10,
+        randomize: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Get words filtered by CEFR level (A1-C2) for study"""
+        try:
+            with self.db_connection.get_connection() as conn:
+                order_clause = (
+                    "ORDER BY RANDOM()" if randomize else "ORDER BY lp.created_at ASC"
+                )
+
+                cursor = conn.execute(
+                    f"""
+                    SELECT w.*, lp.repetitions, lp.easiness_factor, lp.interval_days,
+                           lp.next_review_date, lp.last_reviewed
+                    FROM words w
+                    JOIN learning_progress lp ON w.id = lp.word_id
+                    WHERE lp.telegram_id = ? AND UPPER(w.level) = UPPER(?)
+                    {order_clause}
+                    LIMIT ?
+                    """,  # noqa: S608  # Safe: order_clause is from predefined strings
+                    (telegram_id, level, limit),
+                )
+                return [dict(row) for row in cursor.fetchall()]
+        except Exception as e:
+            logger.error(f"Error getting words by level: {e}")
+            return []
+
+    def get_words_by_lemma_set(
+        self,
+        telegram_id: int,
+        lemmas: list[str],
+        limit: int = 10,
+        randomize: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Get user's words whose lemma (case-insensitive) is in a given set,
+        e.g. a curated list of common verbs, for study"""
+        if not lemmas:
+            return []
+        try:
+            with self.db_connection.get_connection() as conn:
+                order_clause = (
+                    "ORDER BY RANDOM()" if randomize else "ORDER BY lp.created_at ASC"
+                )
+                placeholders = ",".join("?" for _ in lemmas)
+
+                cursor = conn.execute(
+                    f"""
+                    SELECT w.*, lp.repetitions, lp.easiness_factor, lp.interval_days,
+                           lp.next_review_date, lp.last_reviewed
+                    FROM words w
+                    JOIN learning_progress lp ON w.id = lp.word_id
+                    WHERE lp.telegram_id = ? AND LOWER(w.lemma) IN ({placeholders})
+                    {order_clause}
+                    LIMIT ?
+                    """,  # noqa: S608  # Safe: placeholders contains only ? chars
+                    [telegram_id] + [lemma.lower() for lemma in lemmas] + [limit],
+                )
+                return [dict(row) for row in cursor.fetchall()]
+        except Exception as e:
+            logger.error(f"Error getting words by lemma set: {e}")
+            return []
+
+    def get_recent_words(
+        self, telegram_id: int, limit: int = 10
+    ) -> list[dict[str, Any]]:
+        """Get the most recently added words for study, regardless of SM2 due date"""
+        try:
+            with self.db_connection.get_connection() as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT w.*, lp.repetitions, lp.easiness_factor, lp.interval_days,
+                           lp.next_review_date, lp.last_reviewed
+                    FROM words w
+                    JOIN learning_progress lp ON w.id = lp.word_id
+                    WHERE lp.telegram_id = ?
+                    ORDER BY lp.created_at DESC
+                    LIMIT ?
+                    """,
+                    (telegram_id, limit),
+                )
+                return [dict(row) for row in cursor.fetchall()]
+        except Exception as e:
+            logger.error(f"Error getting recent words: {e}")
+            return []
+
     def add_words_to_user(
         self, telegram_id: int, words_data: list[dict[str, Any]]
     ) -> int:
@@ -291,8 +413,8 @@ class WordRepository:
                             logger.debug(f"Creating new word entry for '{lemma}'")
                             cursor = conn.execute(
                                 """
-                                INSERT INTO words (lemma, part_of_speech, article, translation, example, additional_forms, confidence)
-                                VALUES (?, ?, ?, ?, ?, ?, ?)
+                                INSERT INTO words (lemma, part_of_speech, article, translation, example, additional_forms, confidence, level)
+                                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                                 """,
                                 (
                                     lemma,
@@ -302,6 +424,7 @@ class WordRepository:
                                     word_data.get("example", ""),
                                     word_data.get("additional_forms"),
                                     word_data.get("confidence", 1.0),
+                                    word_data.get("level"),
                                 ),
                             )
                             word_id = cursor.lastrowid

--- a/src/core/handlers/command_handlers.py
+++ b/src/core/handlers/command_handlers.py
@@ -35,6 +35,18 @@ COMMON_VERBS = [
     "erfahren", "benutzen",
 ]
 
+# German question words (Fragewörter), used for the /study_question_words rubric.
+QUESTION_WORDS = [
+    "wer", "was", "wo", "wohin", "woher", "wann", "warum", "wieso",
+    "weshalb", "wie", "welcher", "welche", "welches", "wessen", "wem",
+    "wen", "wieviel", "wie viel", "inwiefern", "inwieweit",
+]
+
+# Core German modal verbs, used for the /study_modal_verbs rubric.
+MODAL_VERBS = [
+    "können", "müssen", "dürfen", "sollen", "wollen", "mögen", "möchten",
+]
+
 
 class CommandHandlers:
     """Handles all bot commands"""
@@ -130,6 +142,8 @@ class CommandHandlers:
 /study_recent [N] - Последние N добавленных слов (по умолчанию 10)
 /study_a1, /study_a2, /study_b1, /study_b2, /study_c1, /study_c2 - Слова по уровню CEFR
 /study_common_verbs - Популярные немецкие глаголы из вашего списка
+/study_question_words - Вопросительные слова (wer, was, wo...)
+/study_modal_verbs - Модальные глаголы (können, müssen, wollen...)
 
 📊 <b>Статистика:</b>
 /stats - Подробная статистика изучения
@@ -165,7 +179,6 @@ class CommandHandlers:
             existing_session = self.session_manager.get_session(telegram_id)
             if existing_session:
                 # Calculate partial statistics for the interrupted session
-                elapsed_time = existing_session.timer.get_elapsed_time()
                 accuracy = (
                     (
                         existing_session.correct_answers
@@ -183,7 +196,6 @@ class CommandHandlers:
 • Слов изучено: <b>{existing_session.current_word_index}/{len(existing_session.words)}</b>
 • Правильных ответов: <b>{existing_session.correct_answers}/{existing_session.total_answers}</b>
 • Точность: <b>{accuracy:.1f}%</b>
-• Время: <b>{elapsed_time:.1f}с</b>
 
 📝 Переходим к добавлению новых слов..."""
 
@@ -579,6 +591,73 @@ class CommandHandlers:
             return
 
         await self._start_study_session(update, common_verb_words, "common_verbs")
+
+    async def study_question_words_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_question_words command - study German question words
+        (Fragewörter)"""
+        if not update.effective_user:
+            return
+
+        user = update.effective_user
+
+        db_user = self.db_manager.get_user_by_telegram_id(user.id)
+        if not db_user:
+            await self._safe_reply(
+                update,
+                "❌ Пользователь не найден. Используйте /start для регистрации.",
+                reply_markup=ReplyKeyboardRemove(),
+            )
+            return
+
+        question_words = self.db_manager.get_words_by_lemma_set(
+            db_user["telegram_id"], QUESTION_WORDS, limit=10
+        )
+
+        if not question_words:
+            await self._safe_reply(
+                update,
+                "📚 Среди ваших слов нет вопросительных слов из списка.\n\n"
+                "Используйте /add для добавления новых слов из текста.",
+                reply_markup=ReplyKeyboardRemove(),
+            )
+            return
+
+        await self._start_study_session(update, question_words, "question_words")
+
+    async def study_modal_verbs_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_modal_verbs command - study German modal verbs"""
+        if not update.effective_user:
+            return
+
+        user = update.effective_user
+
+        db_user = self.db_manager.get_user_by_telegram_id(user.id)
+        if not db_user:
+            await self._safe_reply(
+                update,
+                "❌ Пользователь не найден. Используйте /start для регистрации.",
+                reply_markup=ReplyKeyboardRemove(),
+            )
+            return
+
+        modal_verb_words = self.db_manager.get_words_by_lemma_set(
+            db_user["telegram_id"], MODAL_VERBS, limit=10
+        )
+
+        if not modal_verb_words:
+            await self._safe_reply(
+                update,
+                "📚 Среди ваших слов нет модальных глаголов из списка.\n\n"
+                "Используйте /add для добавления новых слов из текста.",
+                reply_markup=ReplyKeyboardRemove(),
+            )
+            return
+
+        await self._start_study_session(update, modal_verb_words, "modal_verbs")
 
     async def stats_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Handle /stats command"""

--- a/src/core/handlers/command_handlers.py
+++ b/src/core/handlers/command_handlers.py
@@ -15,6 +15,26 @@ from ...word_processor import WordProcessor
 
 logger = logging.getLogger(__name__)
 
+# Curated list of the most frequent German verbs (standard DaF/Goethe-Institut
+# frequency lists), used for the /study_common_verbs rubric.
+COMMON_VERBS = [
+    "sein", "haben", "werden", "können", "müssen", "sollen", "wollen", "mögen",
+    "dürfen", "machen", "gehen", "kommen", "sagen", "geben", "sehen", "wissen",
+    "finden", "denken", "nehmen", "lassen", "stehen", "bleiben", "liegen",
+    "heißen", "halten", "bringen", "führen", "sprechen", "leben", "fahren",
+    "meinen", "fragen", "kennen", "gelten", "stellen", "spielen", "arbeiten",
+    "brauchen", "folgen", "lernen", "verstehen", "setzen", "erhalten",
+    "schreiben", "laufen", "erklären", "sitzen", "ziehen", "scheinen",
+    "fallen", "gehören", "erwarten", "verlieren", "wohnen", "beginnen",
+    "versuchen", "treffen", "schaffen", "kaufen", "erreichen", "feiern",
+    "essen", "trinken", "schlafen", "hören", "lesen", "warten", "helfen",
+    "tragen", "öffnen", "schließen", "zeigen", "lieben", "reisen", "kochen",
+    "tanzen", "singen", "lachen", "weinen", "glauben", "verlassen",
+    "erzählen", "antworten", "verkaufen", "bezahlen", "bestellen",
+    "wechseln", "entscheiden", "vergessen", "erinnern", "wünschen", "hoffen",
+    "erfahren", "benutzen",
+]
+
 
 class CommandHandlers:
     """Handles all bot commands"""
@@ -99,6 +119,17 @@ class CommandHandlers:
 /study_new - Только новые слова (ещё не изучались)
 /study_difficult - Сложные слова (низкий рейтинг успешности)
 /study_verbs - Только глаголы
+/study_nouns - Только существительные
+/study_adjectives - Только прилагательные
+/study_adverbs - Только наречия
+/study_pronouns - Только местоимения
+/study_prepositions - Только предлоги
+/study_conjunctions - Только союзы
+/study_numerals - Только числительные
+/study_interjections - Только междометия
+/study_recent [N] - Последние N добавленных слов (по умолчанию 10)
+/study_a1, /study_a2, /study_b1, /study_b2, /study_c1, /study_c2 - Слова по уровню CEFR
+/study_common_verbs - Популярные немецкие глаголы из вашего списка
 
 📊 <b>Статистика:</b>
 /stats - Подробная статистика изучения
@@ -317,6 +348,237 @@ class CommandHandlers:
             return
 
         await self._start_study_session(update, verb_words, "verbs")
+
+    async def study_recent_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_recent [N] command - study the last N added words"""
+        if not update.effective_user:
+            return
+
+        user = update.effective_user
+
+        db_user = self.db_manager.get_user_by_telegram_id(user.id)
+        if not db_user:
+            await self._safe_reply(
+                update,
+                "❌ Пользователь не найден. Используйте /start для регистрации.",
+                reply_markup=ReplyKeyboardRemove(),
+            )
+            return
+
+        limit = 10
+        if context.args:
+            try:
+                limit = int(context.args[0])
+            except ValueError:
+                await self._safe_reply(
+                    update,
+                    "❌ Укажите число слов, например: /study_recent 20",
+                    reply_markup=ReplyKeyboardRemove(),
+                )
+                return
+        limit = max(1, min(limit, 200))
+
+        recent_words = self.db_manager.get_recent_words(
+            db_user["telegram_id"], limit=limit
+        )
+
+        if not recent_words:
+            await self._safe_reply(
+                update,
+                "📚 У вас пока нет добавленных слов.\n\n"
+                "Используйте /add для добавления новых слов из текста.",
+                reply_markup=ReplyKeyboardRemove(),
+            )
+            return
+
+        await self._start_study_session(update, recent_words, "recent")
+
+    async def _study_pos(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE, part_of_speech: str
+    ):
+        """Shared logic for the flat /study_<pos> commands"""
+        if not update.effective_user:
+            return
+
+        user = update.effective_user
+
+        db_user = self.db_manager.get_user_by_telegram_id(user.id)
+        if not db_user:
+            await self._safe_reply(
+                update,
+                "❌ Пользователь не найден. Используйте /start для регистрации.",
+                reply_markup=ReplyKeyboardRemove(),
+            )
+            return
+
+        pos_words = self.db_manager.get_words_by_part_of_speech(
+            db_user["telegram_id"], part_of_speech, limit=10
+        )
+
+        if not pos_words:
+            await self._safe_reply(
+                update,
+                f"📚 У вас нет слов с частью речи «{part_of_speech}».\n\n"
+                "Используйте /add для добавления новых слов из текста.",
+                reply_markup=ReplyKeyboardRemove(),
+            )
+            return
+
+        await self._start_study_session(update, pos_words, f"pos:{part_of_speech}")
+
+    async def study_nouns_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_nouns command"""
+        await self._study_pos(update, context, "noun")
+
+    async def study_adjectives_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_adjectives command"""
+        await self._study_pos(update, context, "adjective")
+
+    async def study_adverbs_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_adverbs command"""
+        await self._study_pos(update, context, "adverb")
+
+    async def study_pronouns_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_pronouns command"""
+        await self._study_pos(update, context, "pronoun")
+
+    async def study_prepositions_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_prepositions command"""
+        await self._study_pos(update, context, "preposition")
+
+    async def study_conjunctions_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_conjunctions command"""
+        await self._study_pos(update, context, "conjunction")
+
+    async def study_numerals_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_numerals command"""
+        await self._study_pos(update, context, "numeral")
+
+    async def study_interjections_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_interjections command"""
+        await self._study_pos(update, context, "interjection")
+
+    async def _study_level(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE, level: str
+    ):
+        """Shared logic for the flat /study_<level> commands"""
+        if not update.effective_user:
+            return
+
+        user = update.effective_user
+
+        db_user = self.db_manager.get_user_by_telegram_id(user.id)
+        if not db_user:
+            await self._safe_reply(
+                update,
+                "❌ Пользователь не найден. Используйте /start для регистрации.",
+                reply_markup=ReplyKeyboardRemove(),
+            )
+            return
+
+        level_words = self.db_manager.get_words_by_level(
+            db_user["telegram_id"], level, limit=10
+        )
+
+        if not level_words:
+            await self._safe_reply(
+                update,
+                f"📚 У вас нет слов уровня «{level}».\n\n"
+                "Слова получают уровень при добавлении через /add — "
+                "старые слова, добавленные раньше, могут быть без уровня.",
+                reply_markup=ReplyKeyboardRemove(),
+            )
+            return
+
+        await self._start_study_session(update, level_words, f"level:{level}")
+
+    async def study_a1_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_a1 command"""
+        await self._study_level(update, context, "A1")
+
+    async def study_a2_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_a2 command"""
+        await self._study_level(update, context, "A2")
+
+    async def study_b1_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_b1 command"""
+        await self._study_level(update, context, "B1")
+
+    async def study_b2_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_b2 command"""
+        await self._study_level(update, context, "B2")
+
+    async def study_c1_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_c1 command"""
+        await self._study_level(update, context, "C1")
+
+    async def study_c2_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_c2 command"""
+        await self._study_level(update, context, "C2")
+
+    async def study_common_verbs_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /study_common_verbs command - study from a curated list of
+        the most frequent German verbs"""
+        if not update.effective_user:
+            return
+
+        user = update.effective_user
+
+        db_user = self.db_manager.get_user_by_telegram_id(user.id)
+        if not db_user:
+            await self._safe_reply(
+                update,
+                "❌ Пользователь не найден. Используйте /start для регистрации.",
+                reply_markup=ReplyKeyboardRemove(),
+            )
+            return
+
+        common_verb_words = self.db_manager.get_words_by_lemma_set(
+            db_user["telegram_id"], COMMON_VERBS, limit=10
+        )
+
+        if not common_verb_words:
+            await self._safe_reply(
+                update,
+                "📚 Среди ваших слов нет популярных глаголов из списка.\n\n"
+                "Используйте /add для добавления новых слов из текста.",
+                reply_markup=ReplyKeyboardRemove(),
+            )
+            return
+
+        await self._start_study_session(update, common_verb_words, "common_verbs")
 
     async def stats_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Handle /stats command"""

--- a/src/core/handlers/message_handlers.py
+++ b/src/core/handlers/message_handlers.py
@@ -41,7 +41,6 @@ class MessageHandlers:
             existing_session = self.session_manager.get_session(telegram_id)
             if existing_session:
                 # Calculate partial statistics for the interrupted session
-                elapsed_time = existing_session.timer.get_elapsed_time()
                 accuracy = (
                     (
                         existing_session.correct_answers
@@ -59,7 +58,6 @@ class MessageHandlers:
 • Слов изучено: <b>{existing_session.current_word_index}/{len(existing_session.words)}</b>
 • Правильных ответов: <b>{existing_session.correct_answers}/{existing_session.total_answers}</b>
 • Точность: <b>{accuracy:.1f}%</b>
-• Время: <b>{elapsed_time:.1f}с</b>
 
 📝 Переходим к добавлению новых слов..."""
 

--- a/src/core/session/session_manager.py
+++ b/src/core/session/session_manager.py
@@ -88,7 +88,6 @@ class SessionManager:
         existing_session = self.user_sessions.get(telegram_id)
         if existing_session:
             # Calculate partial statistics for the interrupted session
-            elapsed_time = existing_session.timer.get_elapsed_time()
             accuracy = (
                 (
                     existing_session.correct_answers
@@ -106,7 +105,6 @@ class SessionManager:
 • Слов изучено: <b>{existing_session.current_word_index}/{len(existing_session.words)}</b>
 • Правильных ответов: <b>{existing_session.correct_answers}/{existing_session.total_answers}</b>
 • Точность: <b>{accuracy:.1f}%</b>
-• Время: <b>{elapsed_time:.1f}с</b>
 
 🔄 Начинаем новую сессию изучения..."""
 
@@ -290,7 +288,6 @@ class SessionManager:
 • Слов изучено: <b>{len(session.words)}</b>
 • Правильных ответов: <b>{session.correct_answers}/{session.total_answers}</b>
 • Точность: <b>{accuracy:.1f}%</b>
-• Время: <b>{session.timer.get_elapsed_time():.1f}с</b>
 
 🎯 Отличная работа! Продолжайте изучение для лучшего запоминания."""
 
@@ -322,7 +319,6 @@ class SessionManager:
 • Слов изучено: <b>{len(session.words)}</b>
 • Правильных ответов: <b>{session.correct_answers}/{session.total_answers}</b>
 • Точность: <b>{accuracy:.1f}%</b>
-• Время: <b>{session.timer.get_elapsed_time():.1f}с</b>
 
 🎯 Отличная работа! Продолжайте изучение для лучшего запоминания."""
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -69,13 +69,20 @@ def format_progress_stats(stats: dict[str, Any]) -> str:
     total_words = stats.get("total_words", 0)
     due_words = stats.get("due_words", 0)
     new_words = stats.get("new_words", 0)
+    words_today = stats.get("words_today", 0)
     avg_success_rate = stats.get("average_accuracy", 0.0)
+    correct_reviews = stats.get("correct_reviews", 0)
+    incorrect_reviews = stats.get("incorrect_reviews", 0)
+    study_streak = stats.get("study_streak", 0)
 
     result = "📊 Ваша статистика:\n\n"
     result += f"📚 Всего слов: {total_words}\n"
     result += f"🔄 К повторению: {due_words}\n"
     result += f"🆕 Новых слов: {new_words}\n"
-    result += f"✅ Средний успех: {avg_success_rate:.1%}\n"
+    result += f"➕ Добавлено сегодня: {words_today}\n"
+    result += f"🔥 Дней подряд: {study_streak}\n"
+    result += f"✅ Средний успех (30д): {avg_success_rate:.1%}\n"
+    result += f"   верно: {correct_reviews} / неверно: {incorrect_reviews}\n"
 
     return result
 

--- a/src/word_processor.py
+++ b/src/word_processor.py
@@ -30,6 +30,7 @@ class ProcessedWord:
     example: str
     additional_forms: str | None
     confidence: float = 1.0
+    level: str | None = None
 
 
 def validate_article(
@@ -362,6 +363,7 @@ class WordProcessor:
                 example=existing_word["example"] or "",
                 additional_forms=existing_word["additional_forms"],
                 confidence=1.0,
+                level=existing_word.get("level"),
             )
 
         # Process new word with OpenAI
@@ -476,6 +478,8 @@ For each German word, provide:
 4. Russian translation
 5. Example sentence in German
 6. Additional forms (plural for nouns, conjugations for verbs, etc.)
+7. CEFR level (A1, A2, B1, B2, C1, or C2) — your best estimate of how
+   advanced/rare this word is for a German learner
 
 Always respond in valid JSON format with these exact keys:
 - "lemma": base form of the word
@@ -485,6 +489,26 @@ Always respond in valid JSON format with these exact keys:
 - "example": German example sentence
 - "additional_forms": JSON string with additional forms
 - "confidence": confidence score from 0.0 to 1.0
+- "level": one of "A1", "A2", "B1", "B2", "C1", "C2"
+
+Strict rules:
+- "translation" must be written entirely in Russian. Never repeat, echo, or
+  include the German word (or any German text) inside "translation" — if you
+  cannot translate a word, lower "confidence" instead of leaving it untranslated.
+- "example" must be a single plain German sentence only. Never include a
+  Russian translation, gloss, or parenthetical explanation inside "example".
+- "lemma" must always be the canonical dictionary form: verbs as the
+  infinitive (ending in -en/-eln/-ern/-n), nouns as the singular nominative
+  and capitalized, adjectives in their base (non-inflected, non-comparative)
+  form. Never return a conjugated verb, a participle, or a plural noun as
+  "lemma". "lemma" must never be empty — always give your best-guess
+  canonical German form.
+- "part_of_speech" must be exactly one value from: noun, verb, adjective,
+  adverb, pronoun, preposition, conjunction, numeral, interjection, article,
+  particle. Never combine multiple values or add descriptive commentary.
+- Never treat a preposition+article contraction (e.g. "zu dem", "an das",
+  "im", "zum") as a standalone word to analyze — analyze the underlying
+  preposition instead.
 
 Be accurate and provide high-quality linguistic analysis."""
 
@@ -499,6 +523,8 @@ For each German word in the list, provide:
 4. Russian translation
 5. Example sentence in German
 6. Additional forms (plural for nouns, conjugations for verbs, etc.)
+7. CEFR level (A1, A2, B1, B2, C1, or C2) — your best estimate of how
+   advanced/rare this word is for a German learner
 
 Respond with a JSON object where keys are the original words and values are objects with these exact keys:
 - "lemma": base form of the word
@@ -508,6 +534,7 @@ Respond with a JSON object where keys are the original words and values are obje
 - "example": German example sentence
 - "additional_forms": JSON string with additional forms
 - "confidence": confidence score from 0.0 to 1.0
+- "level": one of "A1", "A2", "B1", "B2", "C1", "C2"
 
 Example format:
 {
@@ -518,10 +545,30 @@ Example format:
     "translation": "перевод",
     "example": "Example sentence",
     "additional_forms": "{\"plural\": \"form\"}",
-    "confidence": 0.95
+    "confidence": 0.95,
+    "level": "A1"
   },
   "word2": { ... }
 }
+
+Strict rules:
+- "translation" must be written entirely in Russian. Never repeat, echo, or
+  include the German word (or any German text) inside "translation" — if you
+  cannot translate a word, lower "confidence" instead of leaving it untranslated.
+- "example" must be a single plain German sentence only. Never include a
+  Russian translation, gloss, or parenthetical explanation inside "example".
+- "lemma" must always be the canonical dictionary form: verbs as the
+  infinitive (ending in -en/-eln/-ern/-n), nouns as the singular nominative
+  and capitalized, adjectives in their base (non-inflected, non-comparative)
+  form. Never return a conjugated verb, a participle, or a plural noun as
+  "lemma". "lemma" must never be empty — always give your best-guess
+  canonical German form.
+- "part_of_speech" must be exactly one value from: noun, verb, adjective,
+  adverb, pronoun, preposition, conjunction, numeral, interjection, article,
+  particle. Never combine multiple values or add descriptive commentary.
+- Never treat a preposition+article contraction (e.g. "zu dem", "an das",
+  "im", "zum") as a standalone word to analyze — analyze the underlying
+  preposition instead.
 
 Be accurate and provide high-quality linguistic analysis for all words."""
 
@@ -583,6 +630,7 @@ Be accurate and provide high-quality linguistic analysis for all words."""
                 example=data.get("example", ""),
                 additional_forms=data.get("additional_forms"),
                 confidence=float(data.get("confidence", 1.0)),
+                level=data.get("level"),
             )
         except (TypeError, ValueError) as e:
             logger.error(f"Error parsing OpenAI response: {e}")
@@ -744,6 +792,7 @@ Be accurate and provide high-quality linguistic analysis for all words."""
                         example=word_data.get("example", ""),
                         additional_forms=word_data.get("additional_forms"),
                         confidence=float(word_data.get("confidence", 1.0)),
+                        level=word_data.get("level"),
                     )
                     processed_words.append(processed_word)
                 except (TypeError, ValueError) as e:
@@ -797,6 +846,7 @@ Be accurate and provide high-quality linguistic analysis for all words."""
                     example=existing_word["example"] or "",
                     additional_forms=existing_word["additional_forms"],
                     confidence=1.0,
+                    level=existing_word.get("level"),
                 )
                 processed_words.append(processed_word)
                 existing_words.append(word)

--- a/tests/test_command_interruption.py
+++ b/tests/test_command_interruption.py
@@ -297,7 +297,6 @@ class TestSessionManagerInterruption:
         assert "1/2" in message  # Words studied
         assert "3/4" in message  # Correct answers
         assert "75.0%" in message  # Accuracy
-        assert "Время:" in message  # Time
 
 
 class TestCommandHandlersInterruption:

--- a/tests/test_false_positive_bug.py
+++ b/tests/test_false_positive_bug.py
@@ -128,20 +128,27 @@ class TestFalsePositiveBug:
             "difficult_words": 10,
         }
 
-        # Accuracy query
+        # Correct/incorrect review counts query
         mock_cursor_accuracy = MagicMock()
         mock_cursor_accuracy.fetchone.return_value = {
-            "avg_accuracy": 0.65  # Repository returns this field name
+            "total_reviews": 100,
+            "correct_reviews": 65,
+            "incorrect_reviews": 35,
         }
 
         # Today's activity query
         mock_cursor_today = MagicMock()
         mock_cursor_today.fetchone.return_value = {"reviews_today": 5}
 
+        # Study streak query
+        mock_cursor_streak = MagicMock()
+        mock_cursor_streak.fetchall.return_value = []
+
         mock_conn.execute.side_effect = [
             mock_cursor_main,
             mock_cursor_accuracy,
             mock_cursor_today,
+            mock_cursor_streak,
         ]
 
         # Get stats from repository
@@ -207,7 +214,7 @@ class TestFalsePositiveBug:
 
         # Show the fix
         new_result = format_progress_stats(repo_output)  # Uses fixed version
-        assert "✅ Средний успех: 34.3%" in new_result  # FIXED: Shows correct 34.3%
+        assert "34.3%" in new_result  # FIXED: Shows correct 34.3%
 
         print(f"OLD (buggy): {old_result}")
         print(f"NEW (fixed): {new_result}")

--- a/tests/test_stats_field_mapping.py
+++ b/tests/test_stats_field_mapping.py
@@ -8,10 +8,49 @@ This test suite specifically reproduces and prevents regression of the bug where
 - Result: success rate always showed 0.0% regardless of actual performance
 """
 
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 from src.core.database.repositories.user_repository import UserRepository
 from src.utils import format_progress_stats
+
+
+class TestCalculateStreak:
+    """Test UserRepository._calculate_streak"""
+
+    def test_no_reviews(self):
+        assert UserRepository._calculate_streak(set()) == 0
+
+    def test_streak_ending_today(self):
+        today = datetime.now().date()
+        dates = {
+            today.isoformat(),
+            (today - timedelta(days=1)).isoformat(),
+            (today - timedelta(days=2)).isoformat(),
+        }
+        assert UserRepository._calculate_streak(dates) == 3
+
+    def test_streak_ending_yesterday_still_counts(self):
+        """No review yet today, but streak continues if yesterday was covered"""
+        today = datetime.now().date()
+        dates = {
+            (today - timedelta(days=1)).isoformat(),
+            (today - timedelta(days=2)).isoformat(),
+        }
+        assert UserRepository._calculate_streak(dates) == 2
+
+    def test_streak_broken_by_gap(self):
+        today = datetime.now().date()
+        dates = {
+            today.isoformat(),
+            (today - timedelta(days=3)).isoformat(),
+        }
+        assert UserRepository._calculate_streak(dates) == 1
+
+    def test_no_review_today_or_yesterday_resets_streak(self):
+        today = datetime.now().date()
+        dates = {(today - timedelta(days=2)).isoformat()}
+        assert UserRepository._calculate_streak(dates) == 0
 
 
 class TestStatsFieldMapping:
@@ -121,21 +160,31 @@ class TestStatsFieldMapping:
             "due_words": 0,
             "learned_words": 1,
             "difficult_words": 0,
+            "words_today": 5,
         }
 
-        # Mock the accuracy query response
+        # Mock the correct/incorrect review counts query response
         mock_cursor_accuracy = MagicMock()
-        mock_cursor_accuracy.fetchone.return_value = {"avg_accuracy": 0.343434343434343}
+        mock_cursor_accuracy.fetchone.return_value = {
+            "total_reviews": 99,
+            "correct_reviews": 34,
+            "incorrect_reviews": 65,
+        }
 
         # Mock the today's activity query response
         mock_cursor_today = MagicMock()
         mock_cursor_today.fetchone.return_value = {"reviews_today": 0}
 
+        # Mock the streak query response (no reviews yesterday/today -> streak 0)
+        mock_cursor_streak = MagicMock()
+        mock_cursor_streak.fetchall.return_value = []
+
         # Set up the execute call returns in order
         mock_conn.execute.side_effect = [
             mock_cursor_main,  # Main stats query
-            mock_cursor_accuracy,  # Accuracy query
+            mock_cursor_accuracy,  # Correct/incorrect query
             mock_cursor_today,  # Today's activity query
+            mock_cursor_streak,  # Study streak query
         ]
 
         # Test the actual repository
@@ -146,7 +195,10 @@ class TestStatsFieldMapping:
         assert stats is not None
         assert "total_words" in stats
         assert "average_accuracy" in stats  # This is the critical field
-        assert stats["average_accuracy"] == 0.343434343434343
+        assert stats["average_accuracy"] == 34 / 99
+        assert stats["correct_reviews"] == 34
+        assert stats["incorrect_reviews"] == 65
+        assert stats["words_today"] == 5
 
         # Test that these stats work with format_progress_stats
         formatted = format_progress_stats(stats)
@@ -164,8 +216,10 @@ class TestStatsFieldMapping:
             "difficult_words": 0,
             "average_accuracy": 0.343434343434343,  # 34 good reviews out of 99 total
             "reviews_today": 0,
-            "study_streak": 0,
-            "words_today": 0,
+            "study_streak": 2,
+            "words_today": 3,
+            "correct_reviews": 34,
+            "incorrect_reviews": 65,
         }
 
         # Format the stats
@@ -178,7 +232,10 @@ class TestStatsFieldMapping:
 📚 Всего слов: 716
 🔄 К повторению: 0
 🆕 Новых слов: 623
-✅ Средний успех: 34.3%"""
+➕ Добавлено сегодня: 3
+🔥 Дней подряд: 2
+✅ Средний успех (30д): 34.3%
+   верно: 34 / неверно: 65"""
 
         assert result.strip() == expected_output.strip()
 
@@ -186,7 +243,7 @@ class TestStatsFieldMapping:
         assert "📚 Всего слов: 716" in result
         assert "🔄 К повторению: 0" in result
         assert "🆕 Новых слов: 623" in result
-        assert "✅ Средний успех: 34.3%" in result
+        assert "✅ Средний успех (30д): 34.3%" in result
 
     def test_legacy_field_name_fallback(self):
         """Test that old field name still works for backward compatibility if needed"""

--- a/tests/test_study_level_feature.py
+++ b/tests/test_study_level_feature.py
@@ -10,7 +10,12 @@ from telegram import Message, Update, User
 from telegram.ext import ContextTypes
 
 from src.core.database.database_manager import DatabaseManager
-from src.core.handlers.command_handlers import COMMON_VERBS, CommandHandlers
+from src.core.handlers.command_handlers import (
+    COMMON_VERBS,
+    MODAL_VERBS,
+    QUESTION_WORDS,
+    CommandHandlers,
+)
 
 
 class _BaseFixtures:
@@ -192,6 +197,154 @@ class TestStudyCommonVerbsFeature(_BaseFixtures):
         mock_update.effective_user = None
 
         await command_handlers.study_common_verbs_command(
+            mock_update, self._mock_context()
+        )
+
+        command_handlers.db_manager.get_user_by_telegram_id.assert_not_called()
+        command_handlers._safe_reply.assert_not_called()
+
+
+class TestStudyQuestionWordsFeature(_BaseFixtures):
+    """Test the study_question_words feature"""
+
+    @pytest.fixture
+    def mock_db_manager(self):
+        mock_db = Mock(spec=DatabaseManager)
+        mock_db.get_user_by_telegram_id.return_value = {
+            "telegram_id": 123456789,
+            "username": "testuser",
+            "created_at": "2023-01-01",
+        }
+        mock_db.get_words_by_lemma_set.return_value = [
+            {
+                "id": 1,
+                "lemma": "warum",
+                "part_of_speech": "adverb",
+                "article": None,
+                "translation": "почему",
+                "example": "Warum bist du hier?",
+                "repetitions": 0,
+                "easiness_factor": 2.5,
+                "interval_days": 1,
+                "next_review_date": None,
+                "last_reviewed": None,
+            }
+        ]
+        return mock_db
+
+    @pytest.mark.asyncio
+    async def test_study_question_words_success(self, command_handlers, mock_update):
+        await command_handlers.study_question_words_command(
+            mock_update, self._mock_context()
+        )
+
+        command_handlers.db_manager.get_words_by_lemma_set.assert_called_once_with(
+            123456789, QUESTION_WORDS, limit=10
+        )
+        command_handlers._start_study_session.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_study_question_words_no_words(self, command_handlers, mock_update):
+        command_handlers.db_manager.get_words_by_lemma_set.return_value = []
+
+        await command_handlers.study_question_words_command(
+            mock_update, self._mock_context()
+        )
+
+        call_args = command_handlers._safe_reply.call_args
+        assert "нет вопросительных слов" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_study_question_words_no_user(self, command_handlers, mock_update):
+        command_handlers.db_manager.get_user_by_telegram_id.return_value = None
+
+        await command_handlers.study_question_words_command(
+            mock_update, self._mock_context()
+        )
+
+        call_args = command_handlers._safe_reply.call_args
+        assert "❌ Пользователь не найден" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_study_question_words_no_effective_user(self, command_handlers):
+        mock_update = Mock(spec=Update)
+        mock_update.effective_user = None
+
+        await command_handlers.study_question_words_command(
+            mock_update, self._mock_context()
+        )
+
+        command_handlers.db_manager.get_user_by_telegram_id.assert_not_called()
+        command_handlers._safe_reply.assert_not_called()
+
+
+class TestStudyModalVerbsFeature(_BaseFixtures):
+    """Test the study_modal_verbs feature"""
+
+    @pytest.fixture
+    def mock_db_manager(self):
+        mock_db = Mock(spec=DatabaseManager)
+        mock_db.get_user_by_telegram_id.return_value = {
+            "telegram_id": 123456789,
+            "username": "testuser",
+            "created_at": "2023-01-01",
+        }
+        mock_db.get_words_by_lemma_set.return_value = [
+            {
+                "id": 1,
+                "lemma": "können",
+                "part_of_speech": "verb",
+                "article": None,
+                "translation": "мочь",
+                "example": "Ich kann Deutsch sprechen.",
+                "repetitions": 0,
+                "easiness_factor": 2.5,
+                "interval_days": 1,
+                "next_review_date": None,
+                "last_reviewed": None,
+            }
+        ]
+        return mock_db
+
+    @pytest.mark.asyncio
+    async def test_study_modal_verbs_success(self, command_handlers, mock_update):
+        await command_handlers.study_modal_verbs_command(
+            mock_update, self._mock_context()
+        )
+
+        command_handlers.db_manager.get_words_by_lemma_set.assert_called_once_with(
+            123456789, MODAL_VERBS, limit=10
+        )
+        command_handlers._start_study_session.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_study_modal_verbs_no_words(self, command_handlers, mock_update):
+        command_handlers.db_manager.get_words_by_lemma_set.return_value = []
+
+        await command_handlers.study_modal_verbs_command(
+            mock_update, self._mock_context()
+        )
+
+        call_args = command_handlers._safe_reply.call_args
+        assert "нет модальных глаголов" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_study_modal_verbs_no_user(self, command_handlers, mock_update):
+        command_handlers.db_manager.get_user_by_telegram_id.return_value = None
+
+        await command_handlers.study_modal_verbs_command(
+            mock_update, self._mock_context()
+        )
+
+        call_args = command_handlers._safe_reply.call_args
+        assert "❌ Пользователь не найден" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_study_modal_verbs_no_effective_user(self, command_handlers):
+        mock_update = Mock(spec=Update)
+        mock_update.effective_user = None
+
+        await command_handlers.study_modal_verbs_command(
             mock_update, self._mock_context()
         )
 

--- a/tests/test_study_level_feature.py
+++ b/tests/test_study_level_feature.py
@@ -1,0 +1,199 @@
+"""
+Tests for the flat study-by-level commands (/study_a1, /study_a2, ...) and
+study_common_verbs feature (topic/rubric study)
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from telegram import Message, Update, User
+from telegram.ext import ContextTypes
+
+from src.core.database.database_manager import DatabaseManager
+from src.core.handlers.command_handlers import COMMON_VERBS, CommandHandlers
+
+
+class _BaseFixtures:
+    @pytest.fixture
+    def command_handlers(self, mock_db_manager):
+        handlers = CommandHandlers(
+            db_manager=mock_db_manager,
+            word_processor=Mock(),
+            text_parser=Mock(),
+            srs_system=Mock(),
+            safe_reply_callback=AsyncMock(),
+            process_text_callback=AsyncMock(),
+            start_study_session_callback=AsyncMock(),
+            state_manager=Mock(),
+            session_manager=Mock(),
+        )
+        handlers._safe_reply = AsyncMock()
+        handlers._start_study_session = AsyncMock()
+        return handlers
+
+    @pytest.fixture
+    def mock_update(self):
+        update = Mock(spec=Update)
+        update.effective_user = Mock(spec=User)
+        update.effective_user.id = 123456789
+        update.effective_user.username = "testuser"
+        update.message = Mock(spec=Message)
+        return update
+
+    def _mock_context(self):
+        return Mock(spec=ContextTypes.DEFAULT_TYPE)
+
+
+class TestStudyLevelFeature(_BaseFixtures):
+    """Test the flat /study_<level> commands"""
+
+    @pytest.fixture
+    def mock_db_manager(self):
+        mock_db = Mock(spec=DatabaseManager)
+        mock_db.get_user_by_telegram_id.return_value = {
+            "telegram_id": 123456789,
+            "username": "testuser",
+            "created_at": "2023-01-01",
+        }
+        mock_db.get_words_by_level.return_value = [
+            {
+                "id": 1,
+                "lemma": "Haus",
+                "part_of_speech": "noun",
+                "article": "das",
+                "translation": "дом",
+                "example": "Das Haus ist groß.",
+                "level": "A1",
+                "repetitions": 0,
+                "easiness_factor": 2.5,
+                "interval_days": 1,
+                "next_review_date": None,
+                "last_reviewed": None,
+            }
+        ]
+        return mock_db
+
+    @pytest.mark.parametrize(
+        "command_name,expected_level",
+        [
+            ("study_a1_command", "A1"),
+            ("study_a2_command", "A2"),
+            ("study_b1_command", "B1"),
+            ("study_b2_command", "B2"),
+            ("study_c1_command", "C1"),
+            ("study_c2_command", "C2"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_flat_level_command_calls_correct_level(
+        self, command_handlers, mock_update, command_name, expected_level
+    ):
+        command = getattr(command_handlers, command_name)
+        await command(mock_update, self._mock_context())
+
+        command_handlers.db_manager.get_words_by_level.assert_called_once_with(
+            123456789, expected_level, limit=10
+        )
+        command_handlers._start_study_session.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_study_level_no_words(self, command_handlers, mock_update):
+        command_handlers.db_manager.get_words_by_level.return_value = []
+
+        await command_handlers.study_b2_command(mock_update, self._mock_context())
+
+        call_args = command_handlers._safe_reply.call_args
+        assert "нет слов уровня" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_study_level_no_user(self, command_handlers, mock_update):
+        command_handlers.db_manager.get_user_by_telegram_id.return_value = None
+
+        await command_handlers.study_a1_command(mock_update, self._mock_context())
+
+        call_args = command_handlers._safe_reply.call_args
+        assert "❌ Пользователь не найден" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_study_level_no_effective_user(self, command_handlers):
+        mock_update = Mock(spec=Update)
+        mock_update.effective_user = None
+
+        await command_handlers.study_a1_command(mock_update, self._mock_context())
+
+        command_handlers.db_manager.get_user_by_telegram_id.assert_not_called()
+        command_handlers._safe_reply.assert_not_called()
+
+
+class TestStudyCommonVerbsFeature(_BaseFixtures):
+    """Test the study_common_verbs feature"""
+
+    @pytest.fixture
+    def mock_db_manager(self):
+        mock_db = Mock(spec=DatabaseManager)
+        mock_db.get_user_by_telegram_id.return_value = {
+            "telegram_id": 123456789,
+            "username": "testuser",
+            "created_at": "2023-01-01",
+        }
+        mock_db.get_words_by_lemma_set.return_value = [
+            {
+                "id": 1,
+                "lemma": "gehen",
+                "part_of_speech": "verb",
+                "article": None,
+                "translation": "идти",
+                "example": "Ich gehe nach Hause.",
+                "repetitions": 0,
+                "easiness_factor": 2.5,
+                "interval_days": 1,
+                "next_review_date": None,
+                "last_reviewed": None,
+            }
+        ]
+        return mock_db
+
+    @pytest.mark.asyncio
+    async def test_study_common_verbs_success(self, command_handlers, mock_update):
+        await command_handlers.study_common_verbs_command(
+            mock_update, self._mock_context()
+        )
+
+        command_handlers.db_manager.get_words_by_lemma_set.assert_called_once_with(
+            123456789, COMMON_VERBS, limit=10
+        )
+        command_handlers._start_study_session.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_study_common_verbs_no_words(self, command_handlers, mock_update):
+        command_handlers.db_manager.get_words_by_lemma_set.return_value = []
+
+        await command_handlers.study_common_verbs_command(
+            mock_update, self._mock_context()
+        )
+
+        call_args = command_handlers._safe_reply.call_args
+        assert "нет популярных глаголов" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_study_common_verbs_no_user(self, command_handlers, mock_update):
+        command_handlers.db_manager.get_user_by_telegram_id.return_value = None
+
+        await command_handlers.study_common_verbs_command(
+            mock_update, self._mock_context()
+        )
+
+        call_args = command_handlers._safe_reply.call_args
+        assert "❌ Пользователь не найден" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_study_common_verbs_no_effective_user(self, command_handlers):
+        mock_update = Mock(spec=Update)
+        mock_update.effective_user = None
+
+        await command_handlers.study_common_verbs_command(
+            mock_update, self._mock_context()
+        )
+
+        command_handlers.db_manager.get_user_by_telegram_id.assert_not_called()
+        command_handlers._safe_reply.assert_not_called()

--- a/tests/test_study_pos_feature.py
+++ b/tests/test_study_pos_feature.py
@@ -1,0 +1,127 @@
+"""
+Tests for the flat study-by-part-of-speech commands (/study_nouns, /study_adjectives, ...)
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from telegram import Message, Update, User
+from telegram.ext import ContextTypes
+
+from src.core.database.database_manager import DatabaseManager
+from src.core.handlers.command_handlers import CommandHandlers
+
+
+class TestStudyPosFeature:
+    """Test the flat /study_<pos> commands"""
+
+    @pytest.fixture
+    def mock_db_manager(self):
+        mock_db = Mock(spec=DatabaseManager)
+        mock_db.get_user_by_telegram_id.return_value = {
+            "telegram_id": 123456789,
+            "username": "testuser",
+            "created_at": "2023-01-01",
+        }
+        mock_db.get_words_by_part_of_speech.return_value = [
+            {
+                "id": 1,
+                "lemma": "Haus",
+                "part_of_speech": "noun",
+                "article": "das",
+                "translation": "дом",
+                "example": "Das Haus ist groß.",
+                "repetitions": 0,
+                "easiness_factor": 2.5,
+                "interval_days": 1,
+                "next_review_date": None,
+                "last_reviewed": None,
+            }
+        ]
+        return mock_db
+
+    @pytest.fixture
+    def command_handlers(self, mock_db_manager):
+        handlers = CommandHandlers(
+            db_manager=mock_db_manager,
+            word_processor=Mock(),
+            text_parser=Mock(),
+            srs_system=Mock(),
+            safe_reply_callback=AsyncMock(),
+            process_text_callback=AsyncMock(),
+            start_study_session_callback=AsyncMock(),
+            state_manager=Mock(),
+            session_manager=Mock(),
+        )
+        handlers._safe_reply = AsyncMock()
+        handlers._start_study_session = AsyncMock()
+        return handlers
+
+    @pytest.fixture
+    def mock_update(self):
+        update = Mock(spec=Update)
+        update.effective_user = Mock(spec=User)
+        update.effective_user.id = 123456789
+        update.effective_user.username = "testuser"
+        update.message = Mock(spec=Message)
+        return update
+
+    def _mock_context(self):
+        return Mock(spec=ContextTypes.DEFAULT_TYPE)
+
+    @pytest.mark.parametrize(
+        "command_name,expected_pos",
+        [
+            ("study_nouns_command", "noun"),
+            ("study_adjectives_command", "adjective"),
+            ("study_adverbs_command", "adverb"),
+            ("study_pronouns_command", "pronoun"),
+            ("study_prepositions_command", "preposition"),
+            ("study_conjunctions_command", "conjunction"),
+            ("study_numerals_command", "numeral"),
+            ("study_interjections_command", "interjection"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_flat_pos_command_calls_correct_pos(
+        self, command_handlers, mock_update, command_name, expected_pos
+    ):
+        command = getattr(command_handlers, command_name)
+        await command(mock_update, self._mock_context())
+
+        command_handlers.db_manager.get_words_by_part_of_speech.assert_called_once_with(
+            123456789, expected_pos, limit=10
+        )
+        command_handlers._start_study_session.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_study_pos_no_user(self, command_handlers, mock_update):
+        command_handlers.db_manager.get_user_by_telegram_id.return_value = None
+
+        await command_handlers.study_nouns_command(mock_update, self._mock_context())
+
+        command_handlers._safe_reply.assert_called_once()
+        call_args = command_handlers._safe_reply.call_args
+        assert "❌ Пользователь не найден" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_study_pos_no_words(self, command_handlers, mock_update):
+        command_handlers.db_manager.get_words_by_part_of_speech.return_value = []
+
+        await command_handlers.study_adjectives_command(
+            mock_update, self._mock_context()
+        )
+
+        command_handlers._safe_reply.assert_called_once()
+        call_args = command_handlers._safe_reply.call_args
+        assert "нет слов с частью речи" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_study_pos_no_effective_user(self, command_handlers):
+        mock_update = Mock(spec=Update)
+        mock_update.effective_user = None
+
+        await command_handlers.study_nouns_command(mock_update, self._mock_context())
+
+        command_handlers.db_manager.get_user_by_telegram_id.assert_not_called()
+        command_handlers._safe_reply.assert_not_called()

--- a/tests/test_study_recent_feature.py
+++ b/tests/test_study_recent_feature.py
@@ -1,0 +1,157 @@
+"""
+Tests for the study_recent feature (study last N added words)
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from telegram import Message, Update, User
+from telegram.ext import ContextTypes
+
+from src.core.database.database_manager import DatabaseManager
+from src.core.handlers.command_handlers import CommandHandlers
+
+
+class TestStudyRecentFeature:
+    """Test the study_recent feature"""
+
+    @pytest.fixture
+    def mock_db_manager(self):
+        mock_db = Mock(spec=DatabaseManager)
+        mock_db.get_user_by_telegram_id.return_value = {
+            "telegram_id": 123456789,
+            "username": "testuser",
+            "created_at": "2023-01-01",
+        }
+        mock_db.get_recent_words.return_value = [
+            {
+                "id": 2,
+                "lemma": "Vegetation",
+                "part_of_speech": "noun",
+                "article": "die",
+                "translation": "растительность",
+                "example": "Die Vegetation ist vielfältig.",
+                "repetitions": 0,
+                "easiness_factor": 2.5,
+                "interval_days": 1,
+                "next_review_date": None,
+                "last_reviewed": None,
+            },
+            {
+                "id": 1,
+                "lemma": "stolz",
+                "part_of_speech": "adjective",
+                "article": None,
+                "translation": "гордый",
+                "example": "Er ist stolz.",
+                "repetitions": 0,
+                "easiness_factor": 2.5,
+                "interval_days": 1,
+                "next_review_date": None,
+                "last_reviewed": None,
+            },
+        ]
+        return mock_db
+
+    @pytest.fixture
+    def command_handlers(self, mock_db_manager):
+        handlers = CommandHandlers(
+            db_manager=mock_db_manager,
+            word_processor=Mock(),
+            text_parser=Mock(),
+            srs_system=Mock(),
+            safe_reply_callback=AsyncMock(),
+            process_text_callback=AsyncMock(),
+            start_study_session_callback=AsyncMock(),
+            state_manager=Mock(),
+            session_manager=Mock(),
+        )
+        handlers._safe_reply = AsyncMock()
+        handlers._start_study_session = AsyncMock()
+        return handlers
+
+    @pytest.fixture
+    def mock_update(self):
+        update = Mock(spec=Update)
+        update.effective_user = Mock(spec=User)
+        update.effective_user.id = 123456789
+        update.effective_user.username = "testuser"
+        update.message = Mock(spec=Message)
+        return update
+
+    def _mock_context(self, args=None):
+        context = Mock(spec=ContextTypes.DEFAULT_TYPE)
+        context.args = args or []
+        return context
+
+    @pytest.mark.asyncio
+    async def test_study_recent_default_limit(self, command_handlers, mock_update):
+        await command_handlers.study_recent_command(mock_update, self._mock_context())
+
+        command_handlers.db_manager.get_recent_words.assert_called_once_with(
+            123456789, limit=10
+        )
+        command_handlers._start_study_session.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_study_recent_custom_limit(self, command_handlers, mock_update):
+        await command_handlers.study_recent_command(
+            mock_update, self._mock_context(["50"])
+        )
+
+        command_handlers.db_manager.get_recent_words.assert_called_once_with(
+            123456789, limit=50
+        )
+
+    @pytest.mark.asyncio
+    async def test_study_recent_limit_clamped_to_max(
+        self, command_handlers, mock_update
+    ):
+        await command_handlers.study_recent_command(
+            mock_update, self._mock_context(["9999"])
+        )
+
+        command_handlers.db_manager.get_recent_words.assert_called_once_with(
+            123456789, limit=200
+        )
+
+    @pytest.mark.asyncio
+    async def test_study_recent_invalid_arg(self, command_handlers, mock_update):
+        await command_handlers.study_recent_command(
+            mock_update, self._mock_context(["abc"])
+        )
+
+        command_handlers.db_manager.get_recent_words.assert_not_called()
+        command_handlers._safe_reply.assert_called_once()
+        call_args = command_handlers._safe_reply.call_args
+        assert "Укажите число слов" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_study_recent_no_user(self, command_handlers, mock_update):
+        command_handlers.db_manager.get_user_by_telegram_id.return_value = None
+
+        await command_handlers.study_recent_command(mock_update, self._mock_context())
+
+        command_handlers._safe_reply.assert_called_once()
+        call_args = command_handlers._safe_reply.call_args
+        assert "❌ Пользователь не найден" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_study_recent_no_words(self, command_handlers, mock_update):
+        command_handlers.db_manager.get_recent_words.return_value = []
+
+        await command_handlers.study_recent_command(mock_update, self._mock_context())
+
+        command_handlers._safe_reply.assert_called_once()
+        call_args = command_handlers._safe_reply.call_args
+        assert "нет добавленных слов" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_study_recent_no_effective_user(self, command_handlers):
+        mock_update = Mock(spec=Update)
+        mock_update.effective_user = None
+
+        await command_handlers.study_recent_command(mock_update, self._mock_context())
+
+        command_handlers.db_manager.get_user_by_telegram_id.assert_not_called()
+        command_handlers._safe_reply.assert_not_called()


### PR DESCRIPTION
## Summary
- `/stats` showed hardcoded zeros for words-added-today and study streak, and never surfaced correct/incorrect review counts — now computed for real.
- OpenAI prompts had no guardrails against echoing the German word into the translation or leaking translations into examples; a live-DB audit found this pattern and fixed the worst offenders directly.
- New study rubrics: `/study_recent`, flat per-part-of-speech commands (`/study_nouns`, `/study_adjectives`, ...), flat per-CEFR-level commands (`/study_a1`...`/study_c2`), `/study_common_verbs`, `/study_question_words`, `/study_modal_verbs`.
- Removed the "• Время: Xс" line from session summary/interruption messages (noise).

## Test plan
- [x] `uv run pytest tests/ -q` — no new failures vs `main` baseline (11 pre-existing failures / 25 pre-existing errors, unrelated env-var config issue)
- [x] `make lint` (ruff + mypy) clean
- [x] Verified locally against production Telegram bot token (with prod container temporarily stopped to avoid getUpdates conflict)